### PR TITLE
Use base64 nonce for CSP

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,8 @@
 import { defineMiddleware } from 'astro:middleware';
+import { generateNonce } from './utils/nonce';
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  const nonce = crypto.randomUUID();
+  const nonce = generateNonce();
   context.locals.nonce = nonce;
 
   const response = await next();

--- a/src/utils/nonce.ts
+++ b/src/utils/nonce.ts
@@ -1,3 +1,5 @@
-export function generateNonce(): string {
-  return crypto.randomUUID();
+import { randomBytes } from 'node:crypto';
+
+export function generateNonce(size = 16): string {
+  return randomBytes(size).toString('base64');
 }


### PR DESCRIPTION
## Summary
- generate CSP-compliant nonces using crypto random bytes
- apply new nonce generator in middleware

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894baf87c908322a46993b1bc0e1a74