### PR TITLE
docs: clarify CSS styling approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Kunke Consulting provides expert business and AI consulting services, workshops,
 
 - [Astro](https://astro.build/) (static site generator)
 - TypeScript
-- CSS Modules
+- Global CSS and component-scoped styles (primary stylesheet at `public/styles/global.css`)
 - Responsive design
 
 ---


### PR DESCRIPTION
## Summary
- update styling docs to note global CSS and component-scoped styles
- point to main stylesheet at `public/styles/global.css`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894bc8d2b3c8322bfa3b6d97eb12963