### PR TITLE
feat: add Bartosz Radacz to team

### DIFF
--- a/src/components/TeamMember.astro
+++ b/src/components/TeamMember.astro
@@ -7,10 +7,11 @@ export interface Props {
   specializations: string[];
   linkedin?: string;
   website?: string;
+  email?: string;
   yearsOfCollaboration?: string;
 }
 
-const { name, role, bio, image, specializations, linkedin, website, yearsOfCollaboration } = Astro.props;
+const { name, role, bio, image, specializations, linkedin, website, yearsOfCollaboration, email } = Astro.props;
 ---
 
 <article class="team-member">
@@ -29,6 +30,11 @@ const { name, role, bio, image, specializations, linkedin, website, yearsOfColla
     </div>
     {yearsOfCollaboration && (
       <p class="collaboration">Współpracujemy od: {yearsOfCollaboration}</p>
+    )}
+    {email && (
+      <a href={`mailto:${email}`} class="email-link">
+        {email}
+      </a>
     )}
     {linkedin && (
       <a href={linkedin} class="linkedin-link" target="_blank" rel="noopener noreferrer">

--- a/src/pages/zespol.astro
+++ b/src/pages/zespol.astro
@@ -72,6 +72,18 @@ const teamMembers = [
     website: "", // Brak strony internetowej
     yearsOfCollaboration: "2018"
   },
+  {
+    name: "Bartosz Radacz",
+    role: "Strategia, sprzedaż i marketing B2B",
+    bio: "Specjalizuje się w strategii, sprzedaży i marketingu B2B oraz w wykorzystaniu narzędzi AI w rozwoju biznesu. Wspiera firmy w projektowaniu procesów sprzedażowych, generowaniu leadów oraz optymalizacji działań marketingowych. Łączy analityczne myślenie z elastycznym działaniem, stawiając na rozwiązania o realnym wpływie na wzrost sprzedaży.",
+    image: "/images/blog-placeholder-1.jpg",
+    specializations: [
+      "Strategia B2B",
+      "Sprzedaż i marketing",
+      "AI w biznesie"
+    ],
+    email: "bartosz.radacz@gmail.com",
+  },
 ];
 ---
 


### PR DESCRIPTION
## Summary
- support optional email links in `TeamMember`
- feature Bartosz Radacz on the Polish team page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894bd5888b08322928ddf7d78e466ba