### PR TITLE
Remove legacy CSP headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,9 +3,6 @@
   # Frame protection (replaces X-Frame-Options meta tag)
   X-Frame-Options: DENY
   
-  # Enhanced Content Security Policy with frame-ancestors
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; img-src 'self' data:; media-src 'self'; manifest-src 'self'
-  
   # Additional security headers
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/vercel.json
+++ b/vercel.json
@@ -8,10 +8,6 @@
           "value": "DENY"
         },
         {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; img-src 'self' data:; media-src 'self'; manifest-src 'self'"
-        },
-        {
           "key": "X-Content-Type-Options",
           "value": "nosniff"
         },


### PR DESCRIPTION
## Summary
- remove outdated Content-Security-Policy directives from Vercel and Netlify header configs so they don't block Google Tag Manager/Analytics

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894bcb165b083228b2ca2de7d4680e2