### PR TITLE
Fix company branding in footers and privacy policy

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -194,7 +194,7 @@ const { Content } = await post.render();
         <div class="footer-content">
           <div class="footer-section contact-info-footer">
             <h3>Contact</h3>
-            <p>Błażej ^Kunke Consulting</p>
+            <p>^Kunke Consulting</p>
             <p>
               <a href="mailto:info@kunkeconsulting.pl">info@kunkeconsulting.pl</a>
             </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -214,7 +214,7 @@ import OMnie from '../components/OMnie.astro';
     <div class="footer-content">
       <div class="footer-section contact-info-footer">
         <h3>Contact</h3>
-        <p>Błażej ^Kunke Consulting</p>
+        <p>^Kunke Consulting</p>
         <p>
           <a href="mailto:info@kunkeconsulting.pl">info@kunkeconsulting.pl</a>
         </p>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -4,8 +4,8 @@ import BaseLayout from '../components/BaseLayout.astro';
 ---
 
 <BaseLayout 
-  title="Polityka prywatności i informacje prawne | ^Kunke Consulting"
-  description="Polityka prywatności i informacje prawne dotyczące usług ^Kunke Consulting"
+  title="Polityka prywatności i informacje prawne | Błażej Kunke Consulting"
+  description="Polityka prywatności i informacje prawne dotyczące usług Błażej Kunke Consulting"
 >
 
 <style>
@@ -33,7 +33,7 @@ import BaseLayout from '../components/BaseLayout.astro';
       <section>
         <h2>Polityka prywatności</h2>
         <p>Szanujemy Twoją prywatność. Wszystkie dane osobowe przekazane za pośrednictwem formularza kontaktowego są wykorzystywane wyłącznie w celu realizacji zapytania i nie są udostępniane osobom trzecim.</p>
-        <p>Administratorem danych osobowych jest Błażej ^Kunke Consulting. Masz prawo do wglądu, poprawiania oraz żądania usunięcia swoich danych osobowych.</p>
+        <p>Administratorem danych osobowych jest Błażej Kunke Consulting. Masz prawo do wglądu, poprawiania oraz żądania usunięcia swoich danych osobowych.</p>
       </section>
       <section>
         <h2>Informacje prawne</h2>
@@ -44,7 +44,7 @@ import BaseLayout from '../components/BaseLayout.astro';
       <section>
         <h2>Dane rejestrowe</h2>
         <ul>
-          <li><strong>Nazwa pełna:</strong> Błażej ^Kunke Consulting</li>
+          <li><strong>Nazwa pełna:</strong> Błażej Kunke Consulting</li>
           <li><strong>Adres do doręczeń:</strong> ul. Fosowa 13/1, 62-069 Dąbrówka</li>
           <li><strong>NIP:</strong> 9721222936</li>
           <li><strong>REGON:</strong> 525899400</li>


### PR DESCRIPTION
## Summary
- Use ^Kunke Consulting in site and blog footers
- Use legal name Błażej Kunke Consulting on privacy policy page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894ec9831fc8322a6f4b58cc03bed64