### PR TITLE
feat: add Polish cookie consent banner

### DIFF
--- a/src/components/BaseLayout.astro
+++ b/src/components/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 // src/components/BaseLayout.astro
+import CookieConsent from './CookieConsent.astro';
 export interface Props {
   title: string;
   description?: string;
@@ -66,8 +67,21 @@ const absoluteOgImage = ogImage
       'gtm.start': new Date().getTime(),
       event: 'gtm.js'
     });
-    // (Optional) default consent – flip to 'granted' after user accepts
-    // dataLayer.push({event: 'default_consent_set', consent: {ad_storage:'denied', analytics_storage:'denied', wait_for_update: 500}});
+    (function(){
+      function getCookie(name) {
+        const match = document.cookie.match(new RegExp('(^| )'+name+'=([^;]+)'));
+        return match ? match[2] : null;
+      }
+      const consent = getCookie('cookie_consent') === 'granted' ? 'granted' : 'denied';
+      window.dataLayer.push({
+        event: 'default_consent_set',
+        consent: {
+          ad_storage: consent,
+          analytics_storage: consent,
+          wait_for_update: 500
+        }
+      });
+    })();
   </script>
   <script nonce={nonce}>
     (function(w,d,s,l,i){
@@ -130,5 +144,6 @@ const absoluteOgImage = ogImage
   </noscript>
 
   <slot />
+  <CookieConsent />
 </body>
 </html>

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,0 +1,76 @@
+---
+// src/components/CookieConsent.astro
+---
+<div id="cookie-consent" class="cookie-consent" hidden>
+  <p>
+    Używamy plików cookie do analizy ruchu oraz poprawy działania strony.
+    Więcej informacji znajdziesz w naszej <a href="/privacy-policy">polityce prywatności</a>.
+  </p>
+  <div class="buttons">
+    <button id="cookie-accept" class="accept">Akceptuję</button>
+    <button id="cookie-reject" class="reject">Odrzucam</button>
+  </div>
+</div>
+<script>
+  const banner = document.getElementById('cookie-consent');
+  const consentName = 'cookie_consent';
+  function setCookie(name, value, days) {
+    const date = new Date();
+    date.setTime(date.getTime() + days*24*60*60*1000);
+    document.cookie = `${name}=${value}; expires=${date.toUTCString()}; path=/`;
+  }
+  function getCookie(name) {
+    const match = document.cookie.match(new RegExp('(^| )'+name+'=([^;]+)'));
+    return match ? match[2] : null;
+  }
+  function update(status){
+    setCookie(consentName, status, 365);
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'consent_update',
+      consent: {
+        ad_storage: status,
+        analytics_storage: status
+      }
+    });
+    banner.remove();
+  }
+  if (!getCookie(consentName)) {
+    banner.removeAttribute('hidden');
+  }
+  document.getElementById('cookie-accept').addEventListener('click', () => update('granted'));
+  document.getElementById('cookie-reject').addEventListener('click', () => update('denied'));
+</script>
+<style>
+  .cookie-consent {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #222;
+    color: #fff;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 1000;
+  }
+  .cookie-consent .buttons {
+    display: flex;
+    gap: 1rem;
+  }
+  .cookie-consent button {
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+  }
+  .cookie-consent .accept {
+    background: #4caf50;
+    color: #fff;
+    border: none;
+  }
+  .cookie-consent .reject {
+    background: #f44336;
+    color: #fff;
+    border: none;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add reusable cookie consent banner in Polish storing user preference
- wire Google Tag Manager to honor saved consent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895aae4da7483228216b28edfdad932