### PR TITLE
docs: mention Google Tag cookies in privacy policy

### DIFF
--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -34,6 +34,7 @@ import BaseLayout from '../components/BaseLayout.astro';
         <h2>Polityka prywatności</h2>
         <p>Szanujemy Twoją prywatność. Wszystkie dane osobowe przekazane za pośrednictwem formularza kontaktowego są wykorzystywane wyłącznie w celu realizacji zapytania i nie są udostępniane osobom trzecim.</p>
         <p>Administratorem danych osobowych jest Błażej Kunke Consulting. Masz prawo do wglądu, poprawiania oraz żądania usunięcia swoich danych osobowych.</p>
+        <p>Na naszej stronie wykorzystujemy pliki cookies w ramach usługi Google Tag, które pomagają nam analizować ruch i optymalizować działanie witryny. Możesz w każdej chwili zarządzać ustawieniami cookies w swojej przeglądarce.</p>
       </section>
       <section>
         <h2>Informacje prawne</h2>


### PR DESCRIPTION
## Summary
- clarify privacy policy with note about Google Tag cookies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895c9d0c4888322b6a7155834b83113