### PR TITLE
feat: add David Gardner-Goulet to team

### DIFF
--- a/src/pages/zespol.astro
+++ b/src/pages/zespol.astro
@@ -84,6 +84,17 @@ const teamMembers = [
     ],
     email: "bartosz.radacz@gmail.com",
   },
+  {
+    name: "David Gardner-Goulet (Kanada)",
+    role: "Niezależny trener AI",
+    bio: "David Gardner-Goulet jest niezależnym trenerem AI, specjalizującym się w dostosowywaniu dużych modeli językowych (LLM) do realiów językowych i kulturowych języka kanadyjskiego francuskiego. Współpracuje z wiodącymi firmami, takimi jak Scale AI, Samsung Electronics i LTX, wykorzystując techniki NLP (przetwarzania języka naturalnego) oraz RLHF (uczenia przez wzmacnianie na podstawie opinii człowieka). Pomaga systemom AI generować precyzyjne, zrozumiałe i lokalnie dopasowane odpowiedzi, wspierając rozwój rozwiązań, które ułatwiają codzienne życie.",
+    image: "/images/blog-placeholder-1.jpg", // Zastępcze zdjęcie
+    specializations: [
+      "Dostosowywanie LLM",
+      "NLP",
+      "RLHF"
+    ],
+  },
 ];
 ---
 


### PR DESCRIPTION
## Summary
- add David Gardner-Goulet to the Polish team page with bio and specializations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898b35a6a888322988809e68e144241