### PR TITLE
feat: update David Gardner-Goulet bio

### DIFF
--- a/src/pages/zespol.astro
+++ b/src/pages/zespol.astro
@@ -87,12 +87,12 @@ const teamMembers = [
   {
     name: "David Gardner-Goulet (Kanada)",
     role: "Niezależny trener AI",
-    bio: "David Gardner-Goulet jest niezależnym trenerem AI, specjalizującym się w dostosowywaniu dużych modeli językowych (LLM) do realiów językowych i kulturowych języka kanadyjskiego francuskiego. Współpracuje z wiodącymi firmami, takimi jak Scale AI, Samsung Electronics i LTX, wykorzystując techniki NLP (przetwarzania języka naturalnego) oraz RLHF (uczenia przez wzmacnianie na podstawie opinii człowieka). Pomaga systemom AI generować precyzyjne, zrozumiałe i lokalnie dopasowane odpowiedzi, wspierając rozwój rozwiązań, które ułatwiają codzienne życie.",
-    image: "/images/blog-placeholder-1.jpg", // Zastępcze zdjęcie
+    bio: "David Gardner-Goulet jest niezależnym trenerem AI, specjalizującym się w dostosowywaniu dużych modeli językowych (LLM) do realiów językowych i kulturowych języka kanadyjskiego francuskiego. Współpracuje z wiodącymi firmami, takimi jak Scale AI, Samsung Electronics i LTX, wykorzystując techniki NLP (Natural Language Processing – przetwarzanie języka naturalnego) oraz RLHF (Reinforcement Learning from Human Feedback – uczenie przez wzmacnianie na podstawie opinii człowieka). Pomaga systemom AI generować precyzyjne, zrozumiałe i lokalnie dopasowane odpowiedzi, wspierając rozwój rozwiązań, które ułatwiają codzienne życie.",
+    image: "/images/Dawid_GG.png",
     specializations: [
       "Dostosowywanie LLM",
-      "NLP",
-      "RLHF"
+      "NLP (Natural Language Processing)",
+      "RLHF (Reinforcement Learning from Human Feedback)"
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- Use Dawid_GG.png as David Gardner-Goulet's profile image
- Expand NLP and RLHF acronyms in bio and specializations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898b76551a483229c6b5babf0040fbc