### PR TITLE
Add LinkedIn link for David Gardner-Goulet

### DIFF
--- a/src/pages/zespol.astro
+++ b/src/pages/zespol.astro
@@ -94,6 +94,7 @@ const teamMembers = [
       "NLP (Natural Language Processing)",
       "RLHF (Reinforcement Learning from Human Feedback)"
     ],
+    linkedin: "https://www.linkedin.com/in/david-gardner-goulet-638041212/",
   },
 ];
 ---


### PR DESCRIPTION
## Summary
- add LinkedIn profile URL to David Gardner-Goulet's team member entry

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898b932562c8322ba60b0ead2b63469