### PR TITLE
feat: add hero image to Chat GPT 5 blog post

### DIFF
--- a/src/content/blog/chat-gpt-5.md
+++ b/src/content/blog/chat-gpt-5.md
@@ -3,6 +3,7 @@ title: "Chat GPT 5"
 description: "Wrażenia po premierze ChatGPT-5 i kluczowe korzyści dla biznesu."
 date: 2025-08-07
 tags: ["AI", "ChatGPT-5", "OpenAI", "Biznes"]
+heroImage: "/images/LinkedIn_Aug072025.jpeg"
 ---
 Właśnie wysłuchałem 1,5-godzinny livestream OpenAI.
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,7 +8,7 @@ const blog = defineCollection({
       description: z.string(),
       date: z.date(),
       tags: z.array(z.string()).optional(),
-      // heroImage removed for now
+      heroImage: z.string().optional(),
     }),
 });
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -17,6 +17,7 @@ if (!post) throw new Error(`Post "${slug}" not found`);
 const nonce = Astro.locals.nonce;
 
 const { Content } = await post.render();
+const heroImage = post.data.heroImage || "/images/Workshop2025.JPG";
 ---
 
 <!DOCTYPE html>
@@ -36,11 +37,13 @@ const { Content } = await post.render();
     <meta property="og:type" content="article" />
     <meta property="og:title" content={post.data.title} />
     <meta property="og:description" content={post.data.description} />
+    <meta property="og:image" content={heroImage} />
     
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary" />
+    <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:title" content={post.data.title} />
     <meta property="twitter:description" content={post.data.description} />
+    <meta property="twitter:image" content={heroImage} />
   </head>
   <body>
 
@@ -59,9 +62,8 @@ const { Content } = await post.render();
     -->
     <div class="hero-image-container">
       <div class="hero-image-placeholder">
-        <!-- Replace this placeholder with actual image -->
-        <img 
-          src="/images/Workshop2025.JPG" 
+        <img
+          src={heroImage}
           alt={`Hero image for ${post.data.title}`}
           class="hero-image"
           loading="eager"


### PR DESCRIPTION
## Summary
- allow blog posts to define optional `heroImage`
- render hero image and metadata on blog pages
- attach LinkedIn_Aug072025.jpeg as hero image for Chat GPT 5 article

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689904c9b1488322b90ae3ea4d1a2dcc