### PR TITLE
chore: adjust ai workshop headline

### DIFF
--- a/src/pages/ai-workshop.astro
+++ b/src/pages/ai-workshop.astro
@@ -647,7 +647,7 @@ import BaseLayout from '../components/BaseLayout.astro';
 <!-- Hero Section -->
 <section class="workshop-hero">
   <div class="workshop-hero-content">
-    <h1>Praktyczne Szkolenia AI dla Twojego Zespołu</h1>
+    <h1>Praktyczne szkolenia AI dla twojego zespołu</h1>
     <p class="workshop-hero-subtitle">
       Przekształć swoją firmę dzięki praktycznym warsztatom AI dla polskich przedsiębiorstw. 
       Przygotuj swój zespół do pracy z AI w ciągu jednego dnia dzięki praktycznemu szkoleniu.


### PR DESCRIPTION
## Summary
- reword AI workshop hero headline for consistent casing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run astro -- check` *(fails: Property 'nonce' does not exist on type 'LinkHTMLAttributes')*


------
https://chatgpt.com/codex/tasks/task_e_68b422cd91388322ae6edde6e6a0de4d