### PR TITLE
Add nav bar and refresh AI tool list on student page

### DIFF
--- a/src/pages/ai-dla-ucznia-i-studenta-2025.astro
+++ b/src/pages/ai-dla-ucznia-i-studenta-2025.astro
@@ -193,6 +193,19 @@ import ExperienceSection from '../components/ExperienceSection.astro';
     }
   </style>
 
+  <header class="blog-header">
+    <nav class="breadcrumb">
+      <a href="/">Home</a> > <span>AI dla ucznia i studenta 2025</span>
+    </nav>
+    <a
+      href="https://www.linkedin.com/in/blazejkunke/"
+      class="follow-link"
+      target="_blank"
+      rel="noopener noreferrer"
+      >FOLLOW US</a
+    >
+  </header>
+
   <!-- Hero Section -->
   <section class="workshop-hero">
     <div class="workshop-hero-content">
@@ -212,12 +225,11 @@ import ExperienceSection from '../components/ExperienceSection.astro';
       <span>Gemini</span>
       <span>Notebook&nbsp;LM</span>
       <span>LM&nbsp;Studio</span>
-      <span>Claude</span>
-      <span>Copilot</span>
       <span>Perplexity</span>
-      <span>DALL·E</span>
-      <span>Midjourney</span>
-      <span>Stable Diffusion</span>
+      <span>STORM</span>
+      <span>Nano Banana</span>
+      <span>SORA</span>
+      <span>CODEX</span>
     </div>
     <div class="cta-column">
       <h2>Najnowsze narzędzia AI</h2>


### PR DESCRIPTION
## Summary
- add blog-style navigation header to the student AI landing page
- refresh AI tools list with new entries and remove outdated ones

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc0a7ac07c8322909849d1c222a671