### PR TITLE
style: add section dividers and footer styling

### DIFF
--- a/src/pages/ai-dla-ucznia-i-studenta-2025.astro
+++ b/src/pages/ai-dla-ucznia-i-studenta-2025.astro
@@ -81,22 +81,30 @@ import ExperienceSection from '../components/ExperienceSection.astro';
       box-shadow: 0 6px 18px rgba(74, 144, 226, 0.4);
     }
 
-    .ai-tools-section {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 2rem;
-      align-items: center;
-      padding: 60px 20px;
-      max-width: 1200px;
-      margin: 0 auto;
-    }
+      .ai-tools-section {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 2rem;
+        align-items: center;
+        padding: 60px 20px;
+        max-width: 1200px;
+        margin: 0 auto;
+        background: #f5fbf8;
+      }
 
-    .tool-cloud {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-      justify-content: center;
-    }
+      .section-divider {
+        border: none;
+        height: 4px;
+        background: var(--color-primary);
+        margin: 0;
+      }
+
+      .tool-cloud {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+      }
 
     .tool-cloud span {
       background: #e6f0ee;
@@ -130,12 +138,12 @@ import ExperienceSection from '../components/ExperienceSection.astro';
     }
 
     /* Footer Styles */
-    footer {
-      background: #f8f8fa;
-      padding: 40px 0 0 0;
-      text-align: center;
-      width: 100%;
-    }
+      footer {
+        background: #f2f9f5;
+        padding: 40px 0 0 0;
+        text-align: center;
+        width: 100%;
+      }
     .footer-wrapper {
       display: flex;
       flex-direction: column;
@@ -175,16 +183,16 @@ import ExperienceSection from '../components/ExperienceSection.astro';
       width: 100%;
       text-align: center;
     }
-    .footer-bottom {
-      margin-top: 30px;
-      padding: 20px 10px;
-      background: #ececf2;
-      font-size: 0.85em;
-      color: #555;
-      width: 100%;
-      text-align: center;
-      box-sizing: border-box;
-    }
+      .footer-bottom {
+        margin-top: 30px;
+        padding: 20px 10px;
+        background: #e0eee8;
+        font-size: 0.85em;
+        color: #555;
+        width: 100%;
+        text-align: center;
+        box-sizing: border-box;
+      }
     @media (max-width: 600px) {
       .footer-bottom {
         font-size: 0.75em;
@@ -215,9 +223,13 @@ import ExperienceSection from '../components/ExperienceSection.astro';
         <a href="/Sztuczna%20Inteligencja%20dla%20ucznia%20i%20studenta%202025%20KC.pdf" class="cta-primary" download>Ściągnij za darmo PDF</a>
       </div>
     </div>
-  </section>
+    </section>
 
-  <ExperienceSection />
+    <hr class="section-divider" />
+
+    <ExperienceSection />
+
+    <hr class="section-divider" />
 
   <section class="ai-tools-section">
     <div class="tool-cloud">
@@ -237,6 +249,8 @@ import ExperienceSection from '../components/ExperienceSection.astro';
       <a href="/Sztuczna%20Inteligencja%20dla%20ucznia%20i%20studenta%202025%20KC.pdf" class="cta-primary" download>Ściągnij darmowy PDF</a>
     </div>
   </section>
+
+  <hr class="section-divider" />
 
   <footer>
     <div class="footer-wrapper">


### PR DESCRIPTION
## Summary
- Add section divider style and apply to split hero, content, and footer
- Give AI tools section and footer subtle green backgrounds for visual separation
- Tweak footer bottom color for consistent look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc0d6b4778832285d74c3a775fc212