### PR TITLE
Reduce StudentReport CTA size on desktop

### DIFF
--- a/src/components/StudentReport.astro
+++ b/src/components/StudentReport.astro
@@ -50,6 +50,12 @@
     margin-bottom: 1.25rem;
     color: #555;
   }
+  @media (min-width: 768px) {
+    .cta-btn {
+      padding: 10px 20px;
+      font-size: 0.9rem;
+    }
+  }
   @media (max-width: 768px) {
     .student-report {
       grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Adjust StudentReport component to shrink PDF CTA on screens wider than 768px for better desktop proportions.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc39e2882c8322b6ec663d19bb9452