### PR TITLE
Narrow PDF CTA button on desktop

### DIFF
--- a/src/components/StudentReport.astro
+++ b/src/components/StudentReport.astro
@@ -52,8 +52,10 @@
   }
   @media (min-width: 768px) {
     .cta-btn {
-      padding: 10px 20px;
+      padding: 8px 16px;
       font-size: 0.9rem;
+      max-width: 240px;
+      text-align: center;
     }
   }
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Reduce padding and constrain width of the "Ściągnij darmowy PDF" button for better desktop appearance.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc4abca0588322bb853bb33397d31b