### PR TITLE
fix: prevent StudentReport CTA from wrapping

### DIFF
--- a/src/components/StudentReport.astro
+++ b/src/components/StudentReport.astro
@@ -50,13 +50,8 @@
     margin-bottom: 1.25rem;
     color: #555;
   }
-  @media (min-width: 768px) {
-    .cta-btn {
-      padding: 8px 16px;
-      font-size: 0.9rem;
-      max-width: 240px;
-      text-align: center;
-    }
+  .cta-btn {
+    white-space: nowrap;
   }
   @media (max-width: 768px) {
     .student-report {


### PR DESCRIPTION
## Summary
- ensure StudentReport call-to-action button stays on one line

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc50013e888322984e49e50578efe4