### PR TITLE
Switch contact form to Google Apps Script backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ The project implements robust security measures:
 - Origin checking enabled in `astro.config.mjs`
 - Security headers including X-Frame-Options, X-Content-Type-Options
 - Nonce-based inline style protection
-- Formspree integration for secure form handling
+- Google Apps Script integration for secure form handling
 
 ### Key Directories
 
@@ -69,7 +69,7 @@ Blog posts are managed through Astro Content Collections with schema defined in 
 
 The site uses a component-based structure with specialized components:
 - `BaseLayout.astro` - Main layout with SEO meta tags, security headers, and styling
-- `ContactForm.astro` - Contact form functionality with Formspree integration
+- `ContactForm.astro` - Contact form functionality with Google Apps Script integration
 - `AiPackages.astro` - AI service offerings display
 - `Excel.astro` - Excel training packages presentation
 - `TeamMember.astro` - Team member profiles with photos and links
@@ -96,7 +96,7 @@ The site includes both Polish and English content with dedicated team pages (`te
 - Uses Inter font family from Google Fonts
 - Includes comprehensive SEO meta tags and Open Graph/Twitter Card support
 - Footer includes contact information and social media links (LinkedIn, Facebook, YouTube)
-- Contact form integrates with Formspree for secure form handling
+- Contact form integrates with Google Apps Script for secure form handling
 - Images are stored in `public/images/` including team photos and service graphics
 - No testing framework is currently configured
 

--- a/SECURITY_HEADERS_GUIDE.md
+++ b/SECURITY_HEADERS_GUIDE.md
@@ -21,8 +21,8 @@ These headers are now configured via server configuration files instead of meta 
   - `script-src 'self' 'unsafe-inline'` - Allow inline scripts (required for Astro)
   - `style-src 'self' 'unsafe-inline' fonts.googleapis.com` - Allow inline styles + Google Fonts
   - `font-src 'self' fonts.gstatic.com` - Allow Google Fonts
-  - `connect-src 'self' formspree.io` - Allow Formspree API calls
-  - `form-action 'self' formspree.io` - Allow form submissions to Formspree
+  - `connect-src 'self' https://script.google.com https://script.googleusercontent.com` - Allow Google Apps Script web app calls
+  - `form-action 'self' https://script.google.com` - Allow form submissions to Google Apps Script
   - `frame-ancestors 'none'` - Prevent embedding (replaces X-Frame-Options)
   - `base-uri 'self'` - Restrict base element
   - `object-src 'none'` - Block plugins

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,17 +1,19 @@
 ---
 /*  ContactForm.astro
-    Lead-capture form wired to Formspree
+    Lead-capture form wired to Google Apps Script
 ---------------------------------------------------------------- */
+const nonce: string | undefined = Astro.locals?.nonce;
 ---
 <form
   class="contact-form"
-  action="https://formspree.io/f/xldlbvep"
+  id="kc-contact"
+  action="https://script.google.com/macros/s/AKfycbz5xjPMBICnaCIvsE52rFHLX57iYORLXleQMUMobIorOvifsaNj5_9LEGsnBdC13NNWdQ/exec"
   method="POST"
 >
   <label for="name">Imię i nazwisko<span aria-hidden="true">*</span></label>
   <input
     id="name"
-    name="name"
+    name="Name"
     type="text"
     placeholder="Twoje imię i nazwisko"
     required
@@ -20,38 +22,66 @@
   <label for="email">Adres e-mail służbowy<span aria-hidden="true">*</span></label>
   <input
     id="email"
-    name="email"
+    name="WorkEmail"
     type="email"
     placeholder="ty@firma.com"
     required
   />
 
   <label for="type">Typ zapytania<span aria-hidden="true">*</span></label>
-  <select id="type" name="type" required>
-    <option value="Consulting">Doradztwo</option>
-    <option value="Training">Szkolenie</option>
-    <option value="Other">Inne</option>
+  <select id="type" name="Type" required>
+    <option value="Doradztwo">Doradztwo</option>
+    <option value="Szkolenie">Szkolenie</option>
+    <option value="Inne">Inne</option>
   </select>
 
   <label for="message">Wiadomość</label>
   <textarea
     id="message"
-    name="message"
+    name="Message"
     placeholder="W czym mogę pomóc?"
     rows="5"
   ></textarea>
 
-  <!-- Extra metadata for clearer emails -->
+  <input type="hidden" name="Referrer" id="kc-referrer" />
+  <input type="hidden" name="UTM" id="kc-utm" />
+  <input type="hidden" name="FormSecret" value="kunke-2025" />
   <input
-    type="hidden"
-    name="_subject"
-    value="Nowe zapytanie ze strony ^Kunke Consulting"
+    class="honeypot"
+    type="text"
+    name="_gotcha"
+    tabindex="-1"
+    autocomplete="off"
+    aria-hidden="true"
   />
-  <input type="hidden" name="_template" value="table" />
 
   <!--  🎉 NEW: matches hero CTA  -->
-  <button type="submit" class="cta-btn">Wyślij wiadomość</button>
+  <button id="kc-submit" type="submit" class="cta-btn">Wyślij wiadomość</button>
 </form>
+
+<script is:inline nonce={nonce}>
+  const form = document.getElementById('kc-contact');
+  if (form) {
+    const submitButton = form.querySelector('#kc-submit');
+    const referrerField = form.querySelector('#kc-referrer');
+    const utmField = form.querySelector('#kc-utm');
+
+    if (referrerField) {
+      referrerField.value = document.referrer || '';
+    }
+
+    if (utmField) {
+      utmField.value = window.location.search || '';
+    }
+
+    form.addEventListener('submit', () => {
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Wysyłanie…';
+      }
+    });
+  }
+</script>
 
 <style>
 /********************  Contact Form Styles  ********************/
@@ -103,6 +133,13 @@
   .contact-form {
     padding: 1.5rem 1rem;
   }
+}
+
+.honeypot {
+  position: absolute;
+  left: -10000px;
+  opacity: 0;
+  pointer-events: none;
 }
 /* Ultra-wide screens: give 4K monitors a wider cap */
 @media (min-width: 2000px) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,13 +30,16 @@ export const onRequest = defineMiddleware(async (context, next) => {
       "'self'",
       'ws://localhost:*',
       'http://localhost:*',
-      'formspree.io',
+      'https://script.google.com',
+      'https://script.googleusercontent.com',
       'https://www.google-analytics.com',
       'https://region1.google-analytics.com',
       'https://*.analytics.google.com',
       'https://*.googletagmanager.com',
       'https://stats.g.doubleclick.net'
     ];
+
+    const formActionSources = ["'self'", 'https://script.google.com'];
 
     const devCsp = [
       "default-src 'self'",
@@ -45,6 +48,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
       "img-src 'self' data: blob: https://www.google-analytics.com https://*.googletagmanager.com https://stats.g.doubleclick.net",
       "font-src 'self' https://fonts.gstatic.com",
       `connect-src ${connectSources.join(' ')}`,
+      `form-action ${formActionSources.join(' ')}`,
       "frame-src https://www.googletagmanager.com"
     ].join('; ');
 
@@ -66,13 +70,16 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
     const connectSources = [
       "'self'",
-      'formspree.io',
+      'https://script.google.com',
+      'https://script.googleusercontent.com',
       'https://www.google-analytics.com',
       'https://region1.google-analytics.com',
       'https://*.analytics.google.com',
       'https://*.googletagmanager.com',
       'https://stats.g.doubleclick.net'
     ];
+
+    const formActionSources = ["'self'", 'https://script.google.com'];
 
     const prodCsp = [
       "default-src 'self'",
@@ -83,6 +90,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
       `style-src ${styleSources.join(' ')}`,
       "font-src 'self' https://fonts.gstatic.com",
       `connect-src ${connectSources.join(' ')}`,
+      `form-action ${formActionSources.join(' ')}`,
       "img-src 'self' data: blob: https://www.google-analytics.com https://*.googletagmanager.com https://stats.g.doubleclick.net",
       "frame-src https://www.googletagmanager.com",
       "worker-src 'self'",


### PR DESCRIPTION
## Summary
- switch the main contact form to post to the Google Apps Script web app and capture referrer/UTM metadata while preserving styling
- extend the CSP middleware and docs to allow the new Apps Script domain and form-action policy
- refresh contributor guidance to mention Google Apps Script instead of Formspree

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9644e3e788322acbecb308a84fa45