### PR TITLE
Point contact form to Google Apps Script endpoint

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -3,13 +3,11 @@
     Lead-capture form wired to Google Apps Script
 ---------------------------------------------------------------- */
 const nonce: string | undefined = Astro.locals?.nonce;
-const formAction =
-  'https://script.google.com/macros/s/AKfycbz5xjPMBICnaCIvsE52rFHLX57iYORLXleQMUMobIorOvifsaNj5_9LEGsnBdC13NNWdQ/exec';
 ---
 <form
   class="contact-form"
   id="kc-contact"
-  action={formAction}
+  action="https://script.google.com/macros/s/AKfycbz5xjPMBICnaCIvsE52rFHLX57iYORLXleQMUMobIorOvifsaNj5_9LEGsnBdC13NNWdQ/exec"
   method="POST"
 >
   <label for="name">Imię i nazwisko<span aria-hidden="true">*</span></label>


### PR DESCRIPTION
## Summary
- inline the contact form action so it posts directly to the provided Google Apps Script URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caace939b08322a1a70bf98047d349