### PR TITLE
Update contact form script to submit via fetch

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -74,11 +74,34 @@ const nonce: string | undefined = Astro.locals?.nonce;
       utmField.value = window.location.search || '';
     }
 
-    form.addEventListener('submit', () => {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault(); // Prevent the default form submission
+
       if (submitButton) {
         submitButton.disabled = true;
         submitButton.textContent = 'Wysyłanie…';
       }
+
+      const formData = new FormData(form);
+      const params = new URLSearchParams(formData);
+
+      fetch(form.action, {
+        method: 'POST',
+        body: params, // Use URLSearchParams
+        mode: 'no-cors' // Use no-cors mode for Google Apps Script
+      })
+      .then(() => {
+        // Redirect to the thank you page after successful submission
+        window.location.href = 'https://kunkeconsulting.pl/thank-you';
+      })
+      .catch((error) => {
+        console.error('Error:', error);
+        // Optionally, handle the error, e.g., show an error message
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = 'Wyślij wiadomość';
+        }
+      });
     });
   }
 </script>


### PR DESCRIPTION
## Summary
- replace the contact form inline script with a version that prevents default submission
- submit the form data via fetch using URLSearchParams and redirect on success
- re-enable the submit button and label if the request throws an error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab5c92df883228895552b6519fb5d