### PR TITLE
Add Konrad Lewandowicz to team page

### DIFF
--- a/src/pages/zespol.astro
+++ b/src/pages/zespol.astro
@@ -14,6 +14,17 @@ const experts = [
     yearsOfCollaboration: "2022"
   },
   {
+    name: "Konrad Lewandowicz",
+    role: "Automatyzacja procesów i integracje e-commerce",
+    bio: "Specjalizuje się w tworzeniu automatyzacji opartych o n8n, integracjach e-commerce (WooCommerce, Allegro, Shopify) oraz optymalizacji procesów biznesowych. Łączy doświadczenie techniczne z praktyką sprzedażową – od pracy w terenie (door-to-door) po negocjacje dużych kontraktów. Wspiera firmy w zwiększaniu efektywności i niezależności poprzez inteligentne rozwiązania automatyzacyjne.",
+    image: "/images/blog-placeholder-1.jpg", // Zastąp docelowym zdjęciem, gdy będzie dostępne
+    specializations: [
+      "Automatyzacja zadań i procesów (n8n, Make, API)",
+      "Integracje e-commerce i zarządzanie stanami magazynowymi",
+      "Sprzedaż i negocjacje biznesowe"
+    ],
+  },
+  {
     name: "Bartosz Radacz",
     role: "Strategia, sprzedaż i marketing B2B",
     bio: "Specjalizuje się w strategii, sprzedaży i marketingu B2B oraz w wykorzystaniu narzędzi AI w rozwoju biznesu. Wspiera firmy w projektowaniu procesów sprzedażowych, generowaniu leadów oraz optymalizacji działań marketingowych. Łączy analityczne myślenie z elastycznym działaniem, stawiając na rozwiązania o realnym wpływie na wzrost sprzedaży.",


### PR DESCRIPTION
## Summary
- add Konrad Lewandowicz to the experts array on the team page with his role, bio, and specializations
- use an existing placeholder image path until a dedicated photo is available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da98ac6d4083229ec728fb7ebc1d97