### PR TITLE
Add availability page and calendar; fix '/avaliability' redirect

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,6 +32,10 @@ export default defineConfig({
     })
   ],
   redirects: {
+    '/avaliability': {
+      status: 301,
+      destination: '/availability'
+    },
     '/ai-excel': {
       status: 301,
       destination: '/szkolenia-ai'

--- a/src/components/AvailabilityCalendar.astro
+++ b/src/components/AvailabilityCalendar.astro
@@ -1,0 +1,272 @@
+---
+import { availability, type AvailabilityStatus } from '../content/availability';
+
+const monthNames = [
+  'styczeń',
+  'luty',
+  'marzec',
+  'kwiecień',
+  'maj',
+  'czerwiec',
+  'lipiec',
+  'sierpień',
+  'wrzesień',
+  'październik',
+  'listopad',
+  'grudzień',
+];
+
+const weekdayNames = ['Pon', 'Wt', 'Śr', 'Czw', 'Pt', 'Sob', 'Niedz'];
+const statusDetails: Record<AvailabilityStatus, { label: string; shortLabel: string }> = {
+  available: { label: 'Dostępny', shortLabel: 'Dostępny' },
+  'partially-available': { label: 'Częściowo dostępny', shortLabel: 'Częściowo' },
+  unavailable: { label: 'Niedostępny', shortLabel: 'Zajęty' },
+};
+
+const today = new Date();
+const todayUtc = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+const calendars = availability.months.map((month) => {
+  const monthIndex = month - 1;
+  const numberOfDays = new Date(Date.UTC(availability.year, month, 0)).getUTCDate();
+  const mondayBasedStartDay = (new Date(Date.UTC(availability.year, monthIndex, 1)).getUTCDay() + 6) % 7;
+  const days = Array.from({ length: numberOfDays }, (_, index) => {
+    const day = index + 1;
+    const dateKey = `${availability.year}-${pad(month)}-${pad(day)}`;
+    const status = availability.days[dateKey] ?? availability.defaultStatus;
+    const dayUtc = Date.UTC(availability.year, monthIndex, day);
+
+    return {
+      day,
+      dateKey,
+      status,
+      statusLabel: statusDetails[status].label,
+      shortStatusLabel: statusDetails[status].shortLabel,
+      isPast: dayUtc < todayUtc,
+      accessibleDate: new Intl.DateTimeFormat('pl-PL', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        timeZone: 'UTC',
+      }).format(new Date(dayUtc)),
+    };
+  });
+
+  return {
+    month,
+    name: monthNames[monthIndex],
+    leadingEmptyDays: Array.from({ length: mondayBasedStartDay }),
+    days,
+  };
+});
+---
+
+<div class="availability-calendar">
+  <div class="legend" aria-label="Legenda statusów dostępności">
+    {(Object.entries(statusDetails) as [AvailabilityStatus, { label: string; shortLabel: string }][]).map(
+      ([status, details]) => (
+        <div class="legend-item">
+          <span class={`status-dot status-${status}`} aria-hidden="true"></span>
+          <span>{details.label}</span>
+        </div>
+      ),
+    )}
+  </div>
+
+  <div class="months-grid">
+    {calendars.map((calendar) => (
+      <section class="month-card" aria-labelledby={`month-${calendar.month}`}>
+        <h2 id={`month-${calendar.month}`}>{calendar.name} {availability.year}</h2>
+
+        <div class="calendar-grid weekday-row" aria-hidden="true">
+          {weekdayNames.map((weekday) => <span>{weekday}</span>)}
+        </div>
+
+        <div class="calendar-grid days-grid">
+          {calendar.leadingEmptyDays.map(() => <span class="empty-day" aria-hidden="true"></span>)}
+          {calendar.days.map(({ day, status, statusLabel, shortStatusLabel, isPast, accessibleDate }) => (
+            <div
+              class:list={['day', `status-${status}`, { 'is-past': isPast }]}
+              aria-label={`${accessibleDate}: ${statusLabel}`}
+              title={`${accessibleDate}: ${statusLabel}`}
+            >
+              <span class="day-number">{day}</span>
+              <span class="day-status" aria-hidden="true">{shortStatusLabel}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+    ))}
+  </div>
+</div>
+
+<style>
+  .availability-calendar {
+    width: 100%;
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem 1.5rem;
+    margin: 0 auto 2rem;
+    padding: 1rem 1.25rem;
+    max-width: 48rem;
+    background: #ffffff;
+    border: 1px solid #dfe8e3;
+    border-radius: 999px;
+    box-shadow: 0 8px 24px rgba(10, 71, 49, 0.07);
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #24332d;
+    font-size: 0.95rem;
+    font-weight: 700;
+  }
+
+  .status-dot {
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.14);
+  }
+
+  .months-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 24rem), 1fr));
+    gap: 1.5rem;
+  }
+
+  .month-card {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 1.35rem;
+    background: #ffffff;
+    border: 1px solid #e1e8e4;
+    border-radius: 18px;
+    box-shadow: 0 12px 35px rgba(10, 71, 49, 0.08);
+  }
+
+  .month-card h2 {
+    margin: 0 0 1.1rem;
+    color: #0a4731;
+    font-size: 1.35rem;
+    text-align: left;
+    text-transform: capitalize;
+  }
+
+  .calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 0.38rem;
+  }
+
+  .weekday-row {
+    margin-bottom: 0.5rem;
+    color: #5c6b65;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .day,
+  .empty-day {
+    min-width: 0;
+    aspect-ratio: 1 / 1;
+  }
+
+  .day {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.22rem;
+    overflow: hidden;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    color: #173027;
+    text-align: center;
+  }
+
+  .day-number {
+    font-size: 0.92rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .day-status {
+    width: 100%;
+    margin-top: 0.25rem;
+    overflow: hidden;
+    font-size: 0.52rem;
+    font-weight: 700;
+    line-height: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .status-available {
+    background: #ccefdc;
+    border-color: #74c899;
+  }
+
+  .status-partially-available {
+    background: #fff0b8;
+    border-color: #e1bd42;
+  }
+
+  .status-unavailable {
+    background: #ffd1cf;
+    border-color: #de7772;
+  }
+
+  .day.is-past {
+    opacity: 0.48;
+    filter: saturate(0.65);
+  }
+
+  @media (max-width: 520px) {
+    .legend {
+      justify-content: flex-start;
+      border-radius: 16px;
+    }
+
+    .month-card {
+      padding: 1rem 0.75rem;
+    }
+
+    .calendar-grid {
+      gap: 0.25rem;
+    }
+
+    .day {
+      border-radius: 8px;
+    }
+
+    .day-number {
+      font-size: 0.82rem;
+    }
+
+    .day-status {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .month-card {
+      transition: transform 180ms ease, box-shadow 180ms ease;
+    }
+
+    .month-card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 40px rgba(10, 71, 49, 0.11);
+    }
+  }
+</style>

--- a/src/content/availability.ts
+++ b/src/content/availability.ts
@@ -1,0 +1,12 @@
+export type AvailabilityStatus = 'available' | 'partially-available' | 'unavailable';
+
+export const availability = {
+  year: 2026,
+  months: [4, 7, 8, 9, 10, 11, 12],
+  defaultStatus: 'available' as AvailabilityStatus,
+  updatedAt: '2026-06-08',
+  days: {
+    // Dodawaj wyjątki w formacie: 'RRRR-MM-DD': 'status'.
+    // Przykład: '2026-07-10': 'unavailable',
+  } as Record<string, AvailabilityStatus>,
+};

--- a/src/pages/availability.astro
+++ b/src/pages/availability.astro
@@ -1,0 +1,246 @@
+---
+import AvailabilityCalendar from '../components/AvailabilityCalendar.astro';
+import BaseLayout from '../components/BaseLayout.astro';
+import { availability } from '../content/availability';
+
+const updatedAt = new Intl.DateTimeFormat('pl-PL', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+}).format(new Date(`${availability.updatedAt}T00:00:00Z`));
+---
+
+<BaseLayout
+  title={`Dostępność ${availability.year} | ^Kunke Consulting`}
+  description={`Kalendarz dostępności Błażeja Kunke na ${availability.year} rok. Sprawdź dostępne, częściowo dostępne i zajęte terminy.`}
+>
+  <main>
+    <header class="availability-hero">
+      <a class="home-link" href="/" aria-label="Wróć na stronę główną">← ^Kunke Consulting</a>
+      <div class="hero-content">
+        <p class="eyebrow">Kalendarz {availability.year}</p>
+        <h1>Moja dostępność</h1>
+        <p class="intro">
+          Sprawdź orientacyjną dostępność na warsztaty, konsultacje i projekty. W sprawie
+          konkretnego terminu napisz lub zadzwoń — potwierdzę go bezpośrednio.
+        </p>
+        <p class="updated">Ostatnia aktualizacja: <time datetime={availability.updatedAt}>{updatedAt}</time></p>
+      </div>
+    </header>
+
+    <section class="calendar-section" aria-label="Kalendarz dostępności">
+      <AvailabilityCalendar />
+    </section>
+
+    <section class="contact-section">
+      <div>
+        <p class="eyebrow">Masz termin na myśli?</p>
+        <h2>Potwierdźmy go</h2>
+        <p>Kalendarz ma charakter orientacyjny. Napisz, aby zarezerwować konkretny dzień.</p>
+      </div>
+      <div class="contact-actions">
+        <a class="primary-action" href="mailto:info@kunkeconsulting.pl">Napisz e-mail</a>
+        <a class="secondary-action" href="tel:+48722156925">+48 722 156 925</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>© {availability.year} ^Kunke Consulting</p>
+  </footer>
+</BaseLayout>
+
+<style>
+  main {
+    min-height: 100vh;
+    background:
+      radial-gradient(circle at 85% 4%, rgba(212, 175, 55, 0.16), transparent 24rem),
+      linear-gradient(180deg, #f3f8f5 0%, #f8faf9 45%, #ffffff 100%);
+  }
+
+  .availability-hero {
+    position: relative;
+    padding: 1.25rem max(5vw, 1.25rem) 4.5rem;
+    overflow: hidden;
+    background: #083f2d;
+    color: #ffffff;
+  }
+
+  .availability-hero::after {
+    position: absolute;
+    right: -9rem;
+    bottom: -15rem;
+    width: 34rem;
+    height: 34rem;
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    border-radius: 50%;
+    box-shadow: 0 0 0 4rem rgba(255, 255, 255, 0.035), 0 0 0 9rem rgba(255, 255, 255, 0.025);
+    content: '';
+  }
+
+  .home-link {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    color: #d8eee4;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .home-link:hover {
+    color: #ffffff;
+  }
+
+  .hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 54rem;
+    margin: 5rem auto 0;
+    text-align: center;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.75rem;
+    color: #d4af37;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0;
+    color: #ffffff;
+    font-size: clamp(2.6rem, 7vw, 5rem);
+    line-height: 1.05;
+    letter-spacing: -0.045em;
+  }
+
+  .intro {
+    max-width: 45rem;
+    margin: 1.5rem auto 0;
+    color: #d8eee4;
+    font-size: clamp(1rem, 2vw, 1.18rem);
+    line-height: 1.75;
+  }
+
+  .updated {
+    display: inline-flex;
+    margin: 1.5rem 0 0;
+    padding: 0.5rem 0.85rem;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+    font-size: 0.82rem;
+  }
+
+  .calendar-section {
+    box-sizing: border-box;
+    width: min(94%, 82rem);
+    margin: 0 auto;
+    padding: 3.5rem 0 4.5rem;
+  }
+
+  .contact-section {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    width: min(90%, 68rem);
+    margin: 0 auto 4.5rem;
+    padding: 2.25rem;
+    border-radius: 20px;
+    background: #ffffff;
+    box-shadow: 0 16px 45px rgba(10, 71, 49, 0.1);
+  }
+
+  .contact-section h2 {
+    margin: 0 0 0.5rem;
+    color: #0a4731;
+    font-size: clamp(1.65rem, 4vw, 2.35rem);
+    text-align: left;
+  }
+
+  .contact-section p:not(.eyebrow) {
+    max-width: 38rem;
+    margin: 0;
+    color: #52605a;
+  }
+
+  .contact-actions {
+    display: flex;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .primary-action,
+  .secondary-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.9rem;
+    padding: 0 1.15rem;
+    border: 1px solid #0a4731;
+    border-radius: 10px;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .primary-action {
+    background: #0a4731;
+    color: #ffffff;
+  }
+
+  .secondary-action {
+    background: #ffffff;
+    color: #0a4731;
+  }
+
+  .primary-action:hover,
+  .secondary-action:hover {
+    background: #d4af37;
+    border-color: #d4af37;
+    color: #083f2d;
+  }
+
+  footer {
+    padding: 1.5rem;
+    background: #062f22;
+    color: #c9ddd4;
+    text-align: center;
+  }
+
+  footer p {
+    margin: 0;
+    font-size: 0.85rem;
+  }
+
+  @media (max-width: 760px) {
+    .availability-hero {
+      padding-bottom: 3.5rem;
+    }
+
+    .hero-content {
+      margin-top: 3.5rem;
+    }
+
+    .calendar-section {
+      padding-top: 2.5rem;
+    }
+
+    .contact-section {
+      align-items: stretch;
+      flex-direction: column;
+      padding: 1.5rem;
+    }
+
+    .contact-actions {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,11 @@
   ],
   "redirects": [
     {
+      "source": "/avaliability",
+      "destination": "/availability",
+      "permanent": true
+    },
+    {
       "source": "/us/",
       "destination": "/en/",
       "permanent": true


### PR DESCRIPTION
### Motivation

- Provide a public calendar that shows availability for 2026 and an easy way for visitors to contact for bookings.
- Keep redirects correct by fixing a misspelled route (`/avaliability`) to point to the new `/availability` page.

### Description

- Added a new availability content model in `src/content/availability.ts` exposing `availability` and the `AvailabilityStatus` type.
- Implemented `src/components/AvailabilityCalendar.astro` which renders per-month calendars, status legend, accessible date labels, and responsive styles.
- Created the page `src/pages/availability.astro` that uses `BaseLayout`, displays the calendar, contact actions, and last-updated metadata.
- Added redirects for the misspelled path in `astro.config.mjs` and `vercel.json` to route `/avaliability` to `/availability` as a 301/permanent redirect.

### Testing

- Ran TypeScript compilation with `tsc --noEmit` to validate types and the new module exports, which succeeded.
- Built the site with `astro build` to verify the new page and assets assemble correctly, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ac6b7c508322969e62dff05c366f)