### PR TITLE
Mark 2026-07-23 as unavailable

### DIFF
--- a/src/content/availability.ts
+++ b/src/content/availability.ts
@@ -18,7 +18,7 @@ export const availability = {
     '2026-07-20': 'available',
     '2026-07-21': 'available',
     '2026-07-22': 'available',
-    '2026-07-23': 'available',
+    '2026-07-23': 'unavailable',
     '2026-07-27': 'available',
     '2026-07-28': 'available',
     '2026-07-30': 'available',


### PR DESCRIPTION
### Motivation
- Zaktualizować kalendarz dostępności, aby oznaczyć 23 lipca 2026 jako niedostępny.

### Description
- Zmieniono status w `src/content/availability.ts`, zastępując `'2026-07-23': 'available'` na `'2026-07-23': 'unavailable'`.

### Testing
- Uruchomiono `npm run build` (sukces), wykonano instalację przeglądarki i zależności Playwright (pomyślnie, z ostrzeżeniami dotyczącymi proxy), oraz wygenerowano pełnostronicowy zrzut ekranu zapisany jako `artifacts/availability-july-23-unavailable.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b8b398c88322b65cd00459abe534)