### PR TITLE
Add Polish version of AI model shutdown blog post (reuses existing SVG)

### DIFF
--- a/src/content/blog/amerykanski-rzad-zablokowal-najlepszy-model-ai-i-co-teraz.md
+++ b/src/content/blog/amerykanski-rzad-zablokowal-najlepszy-model-ai-i-co-teraz.md
@@ -1,0 +1,40 @@
+---
+title: "Amerykański rząd zablokował najlepszy model AI. I co teraz?"
+description: "Fable 5 i Mythos 5 zniknęły po amerykańskiej dyrektywie eksportowej. Co ta blokada oznacza dla firm, Europy i strategii AI?"
+date: 2026-06-13
+author: "Błażej Kunke"
+tags: ["AI", "Anthropic", "Fable 5", "Mythos 5", "Strategia AI", "Europejskie AI"]
+heroImage: "/images/claude-fable-5-pierwszy-polski-test.svg"
+---
+
+Wieczorem (polskiego czasu) 12 czerwca 2026 roku najpotężniejszy model AI na rynku przestał działać. Rząd Stanów Zjednoczonych wysłał list do firmy Anthropic.
+
+## Co się właściwie wydarzyło
+
+Rząd USA wydał dyrektywę eksportową nakazującą Anthropic zawieszenie dostępu do dwóch najpotężniejszych modeli, Fable 5 oraz Mythos 5, dla każdego obcokrajowca, zarówno na terenie Stanów, jak i poza nimi. Ponieważ nie da się tego egzekwować wybiórczo, Anthropic wyłączył oba modele dla wszystkich. Pozostałe modele firmy działają normalnie.
+
+Powodem ma być kwestia bezpieczeństwa narodowego. Rząd twierdzi, że znalazł sposób na obejście zabezpieczeń Fable 5, czyli tak zwany jailbreak. Anthropic obejrzał demonstrację i nie zgodził się z oceną zagrożenia, wskazując, że technika ujawniła garść drobnych, znanych już wcześniej podatności, które inne powszechnie dostępne modele potrafią znaleźć samodzielnie. Anthropic stosuje się do nakazu, jednocześnie publicznie się z nim nie zgadzając, i deklaruje, że pracuje nad przywróceniem dostępu tak szybko, jak to możliwe. W chwili pisania tego tekstu nie ma żadnego konkretnego terminu.
+
+## Testowałem Fable 5 na żywo, po polsku
+
+Od dwóch dni prowadzę serię na YouTube, w której sprawdzam Fable 5 i modele klasy Mythos na realnych zadaniach, po polsku, tak jak korzystałaby z nich faktyczna polska firma.
+
+[Cała playlista z testami Fable 5 i Mythos znajduje się tutaj](https://www.youtube.com/playlist?list=PLih5mUCujWAhOc48bsuM39dnS1YP-SKXo).
+
+Model, z którym nagrywałem kilka godzin temu, nie jest już dostępny.
+
+## Właśnie dlatego europejskie i polskie modele mają znaczenie
+
+Spora część tego, co sprzedaje się jako rewolucja, jest bliższa przydatnemu usprawnieniu. Ale jest pewien haczyk. Nawet jeśli AI okaże się o połowę mniej ważne, niż twierdzą najgłośniejsze głosy, i tak nie chcesz sytuacji, w której jeden obcy rząd może wyłączyć Twoje najważniejsze narzędzie jednym listem. To się właśnie wydarzyło.
+
+Dlatego europejskie modele, takie jak Mistral, oraz polskie modele, takie jak PLLuM i Bielik, nie są ciekawostką ani patriotycznym projektem na boku. Są naszą „polisą ubezpieczeniową”. Trzymają możliwości w jurysdykcji, którą da się realnie zrozumieć, pod regułami, na które masz jakiś wpływ. Nie muszą dziś wygrywać każdego benchmarku. Muszą istnieć, działać wystarczająco dobrze do realnych zadań i być dostępne wtedy, gdy modele z nagłówków gasną. Niezawodny model, do którego zawsze masz dostęp, bije genialny model, który może zniknąć z dnia na dzień.
+
+## Będę informować na bieżąco
+
+Ta historia rozwija się szybko. Anthropic obiecał więcej szczegółów w ciągu dwudziestu czterech godzin, sytuacja może się zmienić, zanim przeczytasz ten tekst, a szersze pytanie o to, kto ma prawo wyłączać modele AI, nie zniknie. Będę to opisywać dalej: wpisy na blogu tutaj oraz materiały na kanale YouTube.
+
+## Jeden zablokowany model nie zatrzymuje pracy
+
+Chcę postawić sprawę jasno. Jeden model wyłączony z sieci nie zatrzymuje moich szkoleń z AI, pracy doradczej ani żadnego z projektów, które prowadzę z klientami.
+
+Więcej już wkrótce.


### PR DESCRIPTION
### Motivation
- Provide a Polish-language version of the article about the Fable 5 / Mythos 5 shutdown so Polish readers have a localized post. 
- Reuse the already-versioned SVG hero image to avoid adding new binary files and to work around the previous "Pliki binarne nie są obsługiwane" PR issue.

### Description
- Add a new Markdown post `src/content/blog/amerykanski-rzad-zablokowal-najlepszy-model-ai-i-co-teraz.md` with Polish frontmatter, author, tags, date and full article content. 
- Reference the existing hero SVG at `/images/claude-fable-5-pierwszy-polski-test.svg` instead of introducing any new image binaries. 
- Include the YouTube playlist link and preserve the same sections as the English article (what happened, live tests, relevance of European/Polish models, follow-ups). 
- Rendered the site locally to confirm the new route `/blog/amerykanski-rzad-zablokowal-najlepszy-model-ai-i-co-teraz/` is generated.

### Testing
- `npm run build` completed successfully and the new page was included in the generated site. 
- `git diff --check` returned no problems. 
- `test -f public/images/claude-fable-5-pierwszy-polski-test.svg` verified the shared hero image exists. 
- Local preview was rendered and a full-page screenshot was captured with Playwright at `/tmp/kunke-screenshots/polish-ai-article.png` to confirm visual output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0cb8277c8322ac61946cd008a8e8)