### PR TITLE
Add HoffMed footer recommendation

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -26,6 +26,13 @@
       </div>
     </div>
   </div>
+  <div class="footer-recommendation" aria-label="Polecany partner szkoleniowy">
+    <p>
+      W ^Kunke Consulting specjalizujemy się w szkoleniach z technologii i AI,
+      a w zakresie szkoleń z pierwszej pomocy w Polsce polecamy
+      <a href="https://hoffmed.pl/" target="_blank" rel="noopener noreferrer">HoffMed — Jakuba Hoffmanna</a>.
+    </p>
+  </div>
   <div class="footer-bottom">
     <p>© 2026 ^Kunke Consulting. Wszystkie nazwy produktów, logotypy i marki są własnością ich odpowiednich właścicieli. Użycie tych nazw, logotypów i marek nie oznacza poparcia.</p>
   </div>
@@ -76,6 +83,23 @@
     margin-bottom: 8px;
     width: 100%;
     text-align: center;
+  }
+  .footer-recommendation {
+    max-width: 900px;
+    margin: 26px auto 0;
+    padding: 0 16px;
+    color: #777;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    text-align: center;
+  }
+  .footer-recommendation a {
+    color: #666;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .footer-recommendation a:hover {
+    color: #444;
   }
   .footer-bottom {
     margin-top: 30px;


### PR DESCRIPTION
### Motivation
- Provide a subtle referral to HoffMed (Jakub Hoffmann) for first-aid training in Poland to support a family member and enable a harmless SEO/SEM-friendly outbound link.
- Keep the recommendation unobtrusive on all pages while including descriptive anchor text that helps search engines understand the referral context.

### Description
- Inserted a new `div` with class `footer-recommendation` and `aria-label="Polecany partner szkoleniowy"` into `src/components/SiteFooter.astro` containing the Polish recommendation and a link to `https://hoffmed.pl/`.
- The link uses `target="_blank" rel="noopener noreferrer"` and contains SEO-friendly anchor text referencing "szkoleń z pierwszej pomocy w Polsce".
- Added CSS for `.footer-recommendation` to render as small gray, centered, unobtrusive text and to style the link with an underline and hover color.

### Testing
- Ran `npm run build` which completed successfully without errors.
- Attempted `npx playwright screenshot --full-page http://127.0.0.1:4321/ screenshots/hoffmed-footer.png` but the Playwright browser download failed with a `403 Domain forbidden` from the CDN so the visual screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3279dcb26c8322b3113ef23d2ba2be)