### PR TITLE
Add Fable 5 relaunch blog post and local SVG hero image

### DIFF
--- a/public/images/ponowne-wdrozenie-fable-5.svg
+++ b/public/images/ponowne-wdrozenie-fable-5.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Ponowne wdrożenie Fable 5</title>
+  <desc id="desc">Minimalistyczna grafika do wpisu blogowego o powrocie modelu Claude Fable 5.</desc>
+  <rect width="1200" height="630" fill="#f7f5f1"/>
+  <circle cx="1025" cy="115" r="145" fill="#ede8df"/>
+  <circle cx="160" cy="520" r="190" fill="#ebe7df"/>
+  <path d="M88 96h1024" stroke="#171717" stroke-width="4" stroke-linecap="round" opacity=".12"/>
+  <text x="600" y="92" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700" fill="#171717">Ogłoszenia</text>
+  <text x="600" y="244" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="84" font-weight="800" fill="#111111">Ponowne wdrożenie</text>
+  <text x="600" y="338" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="96" font-weight="900" fill="#111111">Fable 5</text>
+  <text x="600" y="420" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#171717">1 lipca 2026</text>
+  <g transform="translate(244 476)">
+    <rect width="712" height="70" rx="35" fill="#111111"/>
+    <text x="356" y="45" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700" fill="#f7f5f1">Limity, przekierowania i test dla firm</text>
+  </g>
+  <text x="600" y="586" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#171717">^Kunke Consulting</text>
+</svg>

--- a/src/content/blog/ponowne-wdrozenie-fable-5.md
+++ b/src/content/blog/ponowne-wdrozenie-fable-5.md
@@ -1,0 +1,31 @@
+---
+title: "Ponowne wdrożenie Fable 5: co oznacza dla polskich przedsiębiorców?"
+description: "Anthropic przywraca płacącym użytkownikom Claude dostęp do Fable 5, ale z limitami, przekierowaniami i krótkim oknem testowym do 7 lipca."
+date: 2026-07-01
+author: "Błażej Kunke"
+tags: ["AI", "Anthropic", "Claude", "Fable 5", "Biznes", "YouTube"]
+heroImage: "/images/ponowne-wdrozenie-fable-5.svg"
+---
+
+Firma Anthropic potwierdza: od dzisiaj płacący użytkownicy Claude odzyskują dostęp do modelu **Fable 5**. Jest jednak kilka ważnych szczegółów.
+
+## Najważniejsze ograniczenia
+
+1. Zadania uznane przez system bezpieczeństwa za potencjalnie niebezpieczne w obszarze cyberbezpieczeństwa, na przykład wykrywanie i wykorzystywanie podatności w kodzie, zostaną automatycznie przekierowane do słabszego modelu **Opus 4.8**.
+
+2. Dostęp do Fable 5 w ramach subskrypcji **Pro, Max i Team** obejmuje do **50% tygodniowego limitu użycia** i potrwa tylko do **7 lipca**. Po tej dacie korzystanie z modelu wymaga wykupienia kredytów rozliczanych za rzeczywiste zużycie.
+
+## Co to oznacza dla polskich przedsiębiorców
+
+Mamy kilka dni, żeby przetestować Fable 5 w ramach obecnej subskrypcji Anthropic, jeśli już z niej korzystacie, i ocenić, czy różnica względem innych modeli jest na tyle duża, żeby opłacało się płacić za dodatkowe zużycie po 7 lipca.
+
+Warto też sprawdzić, czy surowy limit i przekierowania w zadaniach programistycznych w praktyce nie utrudniają Wam waszej pracy.
+
+## Pierwszy polski test Fable 5
+
+Ciekawych, jak wygląda Fable 5 w praktyce, zapraszam też na mój kanał na YouTube, gdzie znajdziecie pierwszy polski test Fable 5.
+
+[▶ Obejrzyj test Fable 5 na YouTube](https://www.youtube.com/watch?v=ytqaEjhiDmQ&list=PLih5mUCujWAhOc48bsuM39dnS1YP-SKXo)
+
+Błażej Kunke  
+^KC


### PR DESCRIPTION
### Motivation
- Publish a timely Polish blog post about Anthropic restoring access to Fable 5 while ensuring the article has a reliable local hero image so it doesn't depend on an attached asset.

### Description
- Added `src/content/blog/ponowne-wdrozenie-fable-5.md` containing the post, frontmatter and a YouTube test link with `heroImage: "/images/ponowne-wdrozenie-fable-5.svg"`.
- Added a dedicated SVG hero at `public/images/ponowne-wdrozenie-fable-5.svg` so the article uses a local image asset.
- The post includes notes about model routing to `Opus 4.8`, the 50% weekly usage window and the 7 July testing window for subscribers.

### Testing
- Ran `npm run build` which completed successfully and generated the static site including the route `/blog/ponowne-wdrozenie-fable-5/`.
- Started the dev server with `npm run dev -- --host 127.0.0.1` which launched successfully at `http://127.0.0.1:4321/`.
- Attempted an automated screenshot with Playwright but it failed because the `playwright` package is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44b42395d48322b3e998db2e6a7437)