### PR TITLE
Update Bartosz Mikulski role to AI Engineer across locales

### DIFF
--- a/src/components/TeamSection.astro
+++ b/src/components/TeamSection.astro
@@ -24,10 +24,10 @@ const defaultMembers = [
   },
   {
     name: 'Bartosz Mikulski',
-    role: 'Programista, ekspert IT',
+    role: 'Inżynier AI',
     image: '/images/team/bartosz-mikulski-july-2026-team.jpg',
     webp: '/images/team/bartosz-mikulski-july-2026-team.webp',
-    alt: 'Bartosz Mikulski, programista i ekspert IT',
+    alt: 'Bartosz Mikulski, inżynier AI',
   },
   {
     name: 'Jan Kunke',

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -19,10 +19,10 @@ const teamMembersEn = [
   },
   {
     name: 'Bartosz Mikulski',
-    role: 'Programmer, IT expert',
+    role: 'AI Engineer',
     image: '/images/team/bartosz-mikulski-july-2026-team.jpg',
     webp: '/images/team/bartosz-mikulski-july-2026-team.webp',
-    alt: 'Bartosz Mikulski, programmer and IT expert',
+    alt: 'Bartosz Mikulski, AI engineer',
   },
   {
     name: 'Jan Kunke',

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -19,10 +19,10 @@ const teamMembersFr = [
   },
   {
     name: 'Bartosz Mikulski',
-    role: 'Programmeur, expert IT',
+    role: 'Ingénieur IA',
     image: '/images/team/bartosz-mikulski-july-2026-team.jpg',
     webp: '/images/team/bartosz-mikulski-july-2026-team.webp',
-    alt: 'Bartosz Mikulski, programmeur et expert IT',
+    alt: 'Bartosz Mikulski, ingénieur IA',
   },
   {
     name: 'Jan Kunke',

--- a/src/pages/nl/index.astro
+++ b/src/pages/nl/index.astro
@@ -19,10 +19,10 @@ const teamMembersNl = [
   },
   {
     name: 'Bartosz Mikulski',
-    role: 'Programmeur, IT-expert',
+    role: 'AI-engineer',
     image: '/images/team/bartosz-mikulski-july-2026-team.jpg',
     webp: '/images/team/bartosz-mikulski-july-2026-team.webp',
-    alt: 'Bartosz Mikulski, programmeur en IT-expert',
+    alt: 'Bartosz Mikulski, AI-engineer',
   },
   {
     name: 'Jan Kunke',

--- a/src/pages/uk/index.astro
+++ b/src/pages/uk/index.astro
@@ -19,10 +19,10 @@ const teamMembersUk = [
   },
   {
     name: 'Bartosz Mikulski',
-    role: 'Programmer, IT expert',
+    role: 'AI Engineer',
     image: '/images/team/bartosz-mikulski-july-2026-team.jpg',
     webp: '/images/team/bartosz-mikulski-july-2026-team.webp',
-    alt: 'Bartosz Mikulski, programmer and IT expert',
+    alt: 'Bartosz Mikulski, AI engineer',
   },
   {
     name: 'Jan Kunke',


### PR DESCRIPTION
### Motivation
- Update Bartosz Mikulski’s displayed role and image alt text to reflect his current position as an AI engineer in all language versions of the site.

### Description
- Updated the `role` and corresponding `alt` text for Bartosz Mikulski in `src/components/TeamSection.astro` (Polish) and the localized pages `src/pages/en/index.astro`, `src/pages/uk/index.astro`, `src/pages/fr/index.astro`, and `src/pages/nl/index.astro`.

### Testing
- Ran `npm run build` which completed successfully and produced the static site output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e6df9537c8322a8800c824a592320)