### PR TITLE
Align multilingual AI offers

### DIFF
--- a/src/components/AiPackagesEn.astro
+++ b/src/components/AiPackagesEn.astro
@@ -1,34 +1,35 @@
 ---
-// props could be used later for localisation; hard-coded for now
 const packages = [
   {
     id: 'plant',
-    title: 'AI consultation',
-    tagline: 'Quick diagnosis and first steps',
-    price: 'From £280 + VAT',
+    title: 'AI training for teams',
+    tagline: 'Introduce AI and gain an advantage',
+    price: 'From £1,200 + VAT',
     badge: null,
     bullets: [
-      'Assess the AI potential in your company',
-      'Identify first implementation areas',
-      'Recommend the right AI tools',
-      '90 minutes online or on-site',
-      'Optional meeting recording'
+      'Two tailored training days',
+      'Practical AI tools and playbooks',
+      'Prompt engineering',
+      'AI video, image and audio',
+      'Responsible AI: ethics, environment and law',
+      'Slide deck and certificates',
+      'A practical first step with AI'
     ],
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
   },
   {
     id: 'grow',
-    title: 'AI training for companies',
-    tagline: 'Introduce AI and gain an advantage',
-    price: 'From £1,200 + VAT',
+    title: 'AI implementation',
+    tagline: 'A programme tailored to your organisation',
+    price: 'Pricing on request',
     bullets: [
-      'Two in-person training days',
-      'Practical AI tools',
-      'AI pilot programmes',
-      'AI ethics, environment, law',
-      'AI video, image, audio',
-      'Prompt engineering',
-      'Slide deck and certificate'
+      'Team and process needs assessment',
+      'AI strategy and priorities',
+      'Opportunity workshop',
+      'Mapping practical use cases',
+      'First AI assistants',
+      'Data, governance and AI Act risks',
+      'Pilot programme'
     ],
     badge: 'AI for business',
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
@@ -53,7 +54,7 @@ const packages = [
 ];
 ---
 <section id="ai-packages">
-  <h2>AI training and advisory</h2>
+  <h2>AI training, implementation and projects</h2>
 
   <div class="package-grid">
     {packages.map(pkg => (
@@ -71,9 +72,7 @@ const packages = [
           <div class="spacer" />
           <p class="price" set:html={pkg.price} />
 
-          {pkg.calendly
-            ? <a href="/ai-workshop" class="cta">{pkg.id === 'plant' || pkg.id === 'grow' ? 'Learn more' : 'Let’s talk'}</a>
-            : <a href="#contact" class="cta secondary">Get in touch</a>}
+          <a href={pkg.calendly} class="cta" target="_blank" rel="noopener noreferrer">Book a free 30-minute call</a>
         </div>
       </article>
     ))}

--- a/src/components/AiPackagesFr.astro
+++ b/src/components/AiPackagesFr.astro
@@ -2,32 +2,34 @@
 const packages = [
   {
     id: 'plant',
-    title: 'Consultation IA',
-    tagline: 'Diagnostic rapide et premières actions',
-    price: 'À partir de 325 € HT',
+    title: 'Formation IA pour les équipes',
+    tagline: 'Adoptez l’IA et gagnez en efficacité',
+    price: 'À partir de 1400 € HT',
     badge: null,
     bullets: [
-      "Évaluer le potentiel de l'IA dans votre organisation",
-      "Identifier les premiers cas d'usage",
-      "Recommander les bons outils IA",
-      '90 minutes en ligne ou sur site',
-      'Enregistrement du rendez-vous sur demande'
+      'Deux journées de formation sur mesure',
+      'Outils IA et méthodes pratiques',
+      'Prompt engineering',
+      'IA pour la vidéo, l’image et le son',
+      'IA responsable : éthique, environnement et droit',
+      'Support de présentation et certificats',
+      'Une première étape concrète avec l’IA'
     ],
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
   },
   {
     id: 'grow',
-    title: 'Formation IA pour entreprises',
-    tagline: 'Acculturation rapide et avantage compétitif',
-    price: 'À partir de 1400 € HT',
+    title: 'Déploiement de l’IA',
+    tagline: 'Un programme adapté à votre organisation',
+    price: 'Tarifs sur devis',
     bullets: [
-      'Deux journées de formation en présentiel',
-      'Outils IA concrets pour vos équipes',
-      'Programmes pilotes IA',
-      'Éthique, environnement et cadre légal',
-      'IA pour la vidéo, l’image et le son',
-      'Prompt engineering',
-      'Support de présentation et certificat'
+      'Analyse des besoins des équipes et des processus',
+      'Stratégie IA et priorités',
+      'Atelier d’opportunités',
+      'Cartographie des cas d’usage',
+      'Premiers assistants IA',
+      'Risques liés aux données, à la gouvernance et à l’AI Act',
+      'Programme pilote'
     ],
     badge: 'IA pour les équipes',
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
@@ -52,7 +54,7 @@ const packages = [
 ];
 ---
 <section id="ai-packages">
-  <h2>Formations et conseil IA</h2>
+  <h2>Formation, déploiement et projets IA</h2>
 
   <div class="package-grid">
     {packages.map(pkg => (
@@ -70,9 +72,7 @@ const packages = [
           <div class="spacer" />
           <p class="price" set:html={pkg.price} />
 
-          {pkg.calendly
-            ? <a href="/ai-workshop" class="cta">{pkg.id === 'plant' || pkg.id === 'grow' ? 'Découvrir' : 'Échanger'}</a>
-            : <a href="#contact" class="cta secondary">Contactez-nous</a>}
+          <a href={pkg.calendly} class="cta" target="_blank" rel="noopener noreferrer">Réserver un échange gratuit de 30 min</a>
         </div>
       </article>
     ))}

--- a/src/components/AiPackagesNl.astro
+++ b/src/components/AiPackagesNl.astro
@@ -2,32 +2,34 @@
 const packages = [
   {
     id: 'plant',
-    title: 'AI-consultatie',
-    tagline: 'Snelle diagnose en eerste stappen',
-    price: 'Vanaf 325 EUR + btw',
+    title: 'AI-training voor teams',
+    tagline: 'Introduceer AI en creëer voorsprong',
+    price: 'Vanaf 1400 EUR + btw',
     badge: null,
     bullets: [
-      'Inzicht in het AI-potentieel binnen uw organisatie',
-      'Eerste implementatiegebieden bepalen',
-      'Aanbeveling van de juiste AI-tools',
-      '90 minuten online of op locatie',
-      'Optioneel opname van de sessie'
+      'Twee trainingsdagen op maat',
+      'Praktische AI-tools en werkwijzen',
+      'Prompt engineering',
+      'AI voor video, beeld en audio',
+      'Verantwoorde AI: ethiek, duurzaamheid en wetgeving',
+      'Presentatie en certificaten',
+      'Een praktische eerste stap met AI'
     ],
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
   },
   {
     id: 'grow',
-    title: 'AI-training voor bedrijven',
-    tagline: 'Introduceer AI en creëer voorsprong',
-    price: 'Vanaf 1400 EUR + btw',
+    title: 'AI-implementatie',
+    tagline: 'Een programma op maat van uw organisatie',
+    price: 'Prijs op aanvraag',
     bullets: [
-      'Twee trainingsdagen op locatie',
-      'Praktische AI-tools',
-      'AI-pilotprogramma\'s',
-      'AI-ethiek, duurzaamheid en wetgeving',
-      'AI voor video, beeld en audio',
-      'Prompt engineering',
-      'Presentatie en certificaat'
+      'Analyse van team- en procesbehoeften',
+      'AI-strategie en prioriteiten',
+      'Workshop over kansen',
+      'Praktische use cases in kaart brengen',
+      'Eerste AI-assistenten',
+      'Risico’s rond data, governance en de AI Act',
+      'Pilotprogramma'
     ],
     badge: 'AI voor business',
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
@@ -52,7 +54,7 @@ const packages = [
 ];
 ---
 <section id="ai-packages">
-  <h2>AI-training en advies</h2>
+  <h2>AI-training, implementatie en projecten</h2>
 
   <div class="package-grid">
     {packages.map(pkg => (
@@ -70,9 +72,7 @@ const packages = [
           <div class="spacer" />
           <p class="price" set:html={pkg.price} />
 
-          {pkg.calendly
-            ? <a href="/ai-workshop" class="cta">{pkg.id === 'plant' || pkg.id === 'grow' ? 'Meer informatie' : 'Laten we praten'}</a>
-            : <a href="#contact" class="cta secondary">Neem contact op</a>}
+          <a href={pkg.calendly} class="cta" target="_blank" rel="noopener noreferrer">Plan een gratis gesprek van 30 minuten</a>
         </div>
       </article>
     ))}

--- a/src/components/AiPackagesUk.astro
+++ b/src/components/AiPackagesUk.astro
@@ -2,32 +2,34 @@
 const packages = [
   {
     id: 'plant',
-    title: 'AI consultation',
-    tagline: 'Fast diagnosis and first steps',
-    price: 'From £280 + VAT',
+    title: 'AI training for teams',
+    tagline: 'Introduce AI and gain an edge',
+    price: 'From £1,200 + VAT',
     badge: null,
     bullets: [
-      'Assess the AI potential in your organisation',
-      'Identify quick wins to pilot',
-      'Recommend trusted AI tools',
-      '90 minutes online or on-site in the UK',
-      'Optional meeting recording'
+      'Two tailored training days in the UK',
+      'Hands-on AI tools and playbooks',
+      'Prompt engineering',
+      'AI video, image and audio',
+      'Responsible AI: ethics, environment and law',
+      'Slide deck and certificates',
+      'A practical first step with AI'
     ],
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
   },
   {
     id: 'grow',
-    title: 'AI training for teams',
-    tagline: 'Introduce AI and gain an edge',
-    price: 'From £1,200 + VAT',
+    title: 'AI implementation',
+    tagline: 'A programme tailored to your organisation',
+    price: 'Pricing on request',
     bullets: [
-      'Two tailored training days in the UK',
-      'Hands-on AI tools and playbooks',
-      'AI pilot programmes',
-      'Responsible AI: ethics, environment, law',
-      'AI video, image, audio',
-      'Prompt engineering',
-      'Slide deck and certificate'
+      'Team and process needs assessment',
+      'AI strategy and priorities',
+      'Opportunity workshop',
+      'Mapping practical use cases',
+      'First AI assistants',
+      'Data, governance and AI Act risks',
+      'Pilot programme'
     ],
     badge: 'AI for business',
     calendly: 'https://calendly.com/kunkeconsulting-info/30min'
@@ -52,7 +54,7 @@ const packages = [
 ];
 ---
 <section id="ai-packages">
-  <h2>AI training and advisory in the UK</h2>
+  <h2>AI training, implementation and projects in the UK</h2>
 
   <div class="package-grid">
     {packages.map(pkg => (
@@ -70,9 +72,7 @@ const packages = [
           <div class="spacer" />
           <p class="price" set:html={pkg.price} />
 
-          {pkg.calendly
-            ? <a href="/ai-workshop" class="cta">{pkg.id === 'plant' || pkg.id === 'grow' ? 'Learn more' : 'Let’s talk'}</a>
-            : <a href="#contact" class="cta secondary">Get in touch</a>}
+          <a href={pkg.calendly} class="cta" target="_blank" rel="noopener noreferrer">Book a free 30-minute call</a>
         </div>
       </article>
     ))}

--- a/src/pages/konsultacja-ai.astro
+++ b/src/pages/konsultacja-ai.astro
@@ -22,7 +22,7 @@ const contactPhone = '+48722156925';
           którzy chcą podjąć dobre decyzje o AI bez presji szybkiego szkolenia lub kosztownego wdrożenia.
         </p>
         <div class="cta-row">
-          <a href={calendlyUrl} class="btn btn-primary" target="_blank" rel="noopener noreferrer">Umów 90-minutową konsultację</a>
+          <a href={calendlyUrl} class="btn btn-primary" target="_blank" rel="noopener noreferrer">Umów bezpłatną rozmowę 30 min</a>
           <a href={`mailto:${contactEmail}`} class="btn btn-secondary">Napisz: {contactEmail}</a>
         </div>
       </div>
@@ -209,17 +209,13 @@ const contactPhone = '+48722156925';
 
   <section class="section-padding section-cta">
     <div class="container cta-box">
-      <h2>Umów konsultację AI dla swojej firmy</h2>
-      <p>Wybierz dogodny termin w kalendarzu albo napisz, jaki problem chcesz zdiagnozować.</p>
+      <h2>Umów bezpłatną rozmowę wstępną</h2>
+      <p>W 30 minut omówimy Twój cel i sprawdzimy, czy płatna konsultacja AI jest właściwym następnym krokiem.</p>
       <div class="cta-row center">
-        <a href={calendlyUrl} class="btn btn-primary" target="_blank" rel="noopener noreferrer">Przejdź do Calendly</a>
+        <a href={calendlyUrl} class="btn btn-primary" target="_blank" rel="noopener noreferrer">Umów bezpłatne 30 min</a>
         <a href={`mailto:${contactEmail}`} class="btn btn-secondary">{contactEmail}</a>
         <a href={`tel:${contactPhone}`} class="btn btn-secondary">+48 722 156 925</a>
       </div>
-      <p class="disclaimer">
-        <strong>Uwaga:</strong> testujemy nowe narzędzia i czasami nie jesteśmy w stanie szybko potwierdzić wizyty.
-        W razie wątpliwości prosimy o kontakt mailowy lub telefoniczny.
-      </p>
     </div>
   </section>
 

--- a/src/pages/uk/index.astro
+++ b/src/pages/uk/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../../components/BaseLayoutUk.astro';
 import ContactForm from '../../components/ContactFormEn.astro';
-import AiPackages from '../../components/AiPackagesEn.astro';
+import AiPackages from '../../components/AiPackagesUk.astro';
 import Testimonials from '../../components/testimonialsEn.astro';
 import ExperienceSection from '../../components/ExperienceSectionEn.astro';
 import WorkshopSection from '../../components/WorkshopSectionEn.astro';
@@ -36,7 +36,7 @@ const teamMembersUk = [
 
 <BaseLayout
   title="AI Training and Consulting for UK Teams | ^Kunke Consulting"
-  description="Practical AI consultation, team training, and implementation support for UK organisations. AI consultations from £280 + VAT and team training from £1,200 + VAT."
+  description="Practical AI training, implementation support and ongoing projects for UK organisations. Team training from £1,200 + VAT."
   ogImage="/images/Workshop2025.JPG"
 >
   <style>
@@ -170,8 +170,8 @@ const teamMembersUk = [
       that fit real business processes.
     </p>
     <div class="hero-meta" aria-label="UK AI offer highlights">
-      <span>Consultation from £280 + VAT</span>
       <span>Team training from £1,200 + VAT</span>
+      <span>Implementation and AI projects</span>
       <span>Online or on-site where applicable</span>
     </div>
     <div class="hero-actions">
@@ -183,16 +183,16 @@ const teamMembersUk = [
   <section class="uk-summary" aria-label="UK AI services summary">
     <div class="summary-grid">
       <article class="summary-card">
-        <h2>Fast diagnosis</h2>
-        <p>A 90-minute consultation to identify realistic AI quick wins, tool choices, risks, and next steps.</p>
+        <h2>Team training</h2>
+        <p>Hands-on sessions that turn AI curiosity into practical skills, shared standards, and useful playbooks.</p>
       </article>
       <article class="summary-card">
-        <h2>Team capability</h2>
-        <p>Hands-on AI training for teams that need practical skills, shared standards, and useful internal playbooks.</p>
+        <h2>AI implementation</h2>
+        <p>A tailored programme covering priorities, practical use cases, governance, first assistants, and a pilot.</p>
       </article>
       <article class="summary-card">
-        <h2>Implementation support</h2>
-        <p>Ongoing help with pilots, adoption, governance, and measurable process improvements.</p>
+        <h2>Ongoing AI projects</h2>
+        <p>Long-term support for adoption, governance, and measurable process improvements across teams.</p>
       </article>
     </div>
   </section>


### PR DESCRIPTION
## What changed

- align English, UK, French and Dutch offer tiers with the current Polish structure: training, implementation and ongoing projects
- remove outdated paid consultation prices and 90-minute promises from multilingual pricing
- use a consistent free 30-minute introductory call CTA
- update UK page metadata, hero highlights and service summary
- clarify the Polish consultation page booking CTA and remove the slow-confirmation warning

## Why

The multilingual pages still showed an older consultation-led pricing model that no longer matched the Polish website.

## Validation

- `npm run build`
- checked all five language previews locally
- confirmed outdated £280 / €325 and 90-minute multilingual copy is removed