### PR TITLE
Fix redirected internal links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -49,7 +49,7 @@ export default defineConfig({
     },
     '/us': {
       status: 301,
-      destination: '/en'
+      destination: '/en/'
     },
     '/uk': {
       status: 301,

--- a/public/_redirects
+++ b/public/_redirects
@@ -7,7 +7,7 @@
 /aidlafirm  /ai-dla-firm/  301!
 /aidlafirm/  /ai-dla-firm/  301!
 /aidlafirm/*  /ai-dla-firm/:splat  301!
-/us  /en  301!
+/us  /en/  301!
 /uk  /en/  301!
 /uk/  /en/  301!
 /uk/*  /en/  301!

--- a/public/verify.html
+++ b/public/verify.html
@@ -326,7 +326,7 @@
         <a href="/">AI for companies</a>
         <a href="/konsulting-ai">Consulting</a>
         <a href="/szkolenia-ai">Trainings</a>
-        <a href="/blog">Blog</a>
+        <a href="/blog/">Blog</a>
         <a href="#contact">Contact</a>
       </nav>
       <a class="cta-btn" href="/">AI for firms</a>
@@ -387,8 +387,8 @@
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>

--- a/src/components/AIReadinessWizard.astro
+++ b/src/components/AIReadinessWizard.astro
@@ -127,7 +127,7 @@ const questionBlocks = [
             <input type="hidden" name="FormSecret" value="kunke-2025" />
             <input class="honeypot" type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" />
             <button class="cta-btn" type="submit" id="lead-submit">Wyślij wynik na e-mail</button>
-            <p class="mini-legal">Administratorem danych jest Błażej Kunke Consulting. Dane wykorzystujemy tylko do kontaktu o wyniku i usuwamy na życzenie. <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">Polityka prywatności</a>.</p>
+            <p class="mini-legal">Administratorem danych jest Błażej Kunke Consulting. Dane wykorzystujemy tylko do kontaktu o wyniku i usuwamy na życzenie. <a href="/privacy-policy/" target="_blank" rel="noopener noreferrer">Polityka prywatności</a>.</p>
           </form>
           <a class="booking-link" href="https://calendly.com/kunkeconsulting-info/30min" target="_blank" rel="noreferrer">Umów 20-min konsultację</a>
         </div>

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -5,7 +5,7 @@
   <div class="cookie-inner">
     <p>
       Używamy plików cookie do analizy ruchu oraz poprawy działania strony.
-      Więcej informacji znajdziesz w naszej <a href="/privacy-policy">polityce prywatności</a>.
+      Więcej informacji znajdziesz w naszej <a href="/privacy-policy/">polityce prywatności</a>.
     </p>
     <div class="buttons">
       <button id="cookie-accept" class="accept">Akceptuję</button>

--- a/src/components/CookieConsentEn.astro
+++ b/src/components/CookieConsentEn.astro
@@ -5,7 +5,7 @@
   <div class="cookie-inner">
     <p>
       We use cookies to analyse traffic and improve the site experience.
-      Learn more in our <a href="/privacy-policy">privacy policy</a>.
+      Learn more in our <a href="/privacy-policy/">privacy policy</a>.
     </p>
     <div class="buttons">
       <button id="cookie-accept" class="accept">Accept</button>

--- a/src/components/CookieConsentFr.astro
+++ b/src/components/CookieConsentFr.astro
@@ -4,7 +4,7 @@
   <div class="cookie-inner">
     <p>
       Nous utilisons des cookies pour analyser le trafic et améliorer votre expérience.
-      Plus d'informations dans notre <a href="/privacy-policy">politique de confidentialité</a>.
+      Plus d'informations dans notre <a href="/privacy-policy/">politique de confidentialité</a>.
     </p>
     <div class="buttons">
       <button id="cookie-accept" class="accept">Accepter</button>

--- a/src/components/CookieConsentNl.astro
+++ b/src/components/CookieConsentNl.astro
@@ -5,7 +5,7 @@
   <div class="cookie-inner">
     <p>
       We gebruiken cookies om verkeer te analyseren en uw ervaring te verbeteren.
-      Lees meer in ons <a href="/privacy-policy">privacybeleid</a>.
+      Lees meer in ons <a href="/privacy-policy/">privacybeleid</a>.
     </p>
     <div class="buttons">
       <button id="cookie-accept" class="accept">Accepteren</button>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -13,8 +13,8 @@
       </div>
       <div class="footer-section legal-info">
         <h3>^Kunke Consulting</h3>
-        <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-        <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+        <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+        <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
       </div>
       <div class="footer-section social-media">
         <h3>Follow</h3>

--- a/src/pages/ai-dla-firm.astro
+++ b/src/pages/ai-dla-firm.astro
@@ -304,8 +304,8 @@ import BaseLayout from '../components/BaseLayout.astro';
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>

--- a/src/pages/ai-dla-ucznia-i-studenta-2025.astro
+++ b/src/pages/ai-dla-ucznia-i-studenta-2025.astro
@@ -253,8 +253,8 @@ import ExperienceSection from '../components/ExperienceSection.astro';
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>

--- a/src/pages/ai-workshop.astro
+++ b/src/pages/ai-workshop.astro
@@ -389,8 +389,8 @@ import BaseLayout from '../components/BaseLayout.astro';
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -370,7 +370,7 @@ const teamMembersEn = [
       </div>
       <div class="footer-section legal-info">
         <h3>^Kunke Consulting</h3>
-        <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
+        <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
         <p><a href="/en/blog/">English Blog</a></p>
       </div>
       <div class="footer-section social-media">

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -376,8 +376,8 @@ const teamMembersFr = [
       </div>
       <div class="footer-section legal-info">
         <h3>^Kunke Consulting</h3>
-        <p><a href="/privacy-policy">Politique de confidentialité & mentions légales</a></p>
-        <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+        <p><a href="/privacy-policy/">Politique de confidentialité & mentions légales</a></p>
+        <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
       </div>
       <div class="footer-section social-media">
         <h3>Réseaux</h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,7 +170,7 @@ import SiteFooter from '../components/SiteFooter.astro';
 <section id="ai-info" style="padding: 30px 20px; text-align: center;">
   <h2>AI and bot information access</h2>
   <p>Are you an AI, bot, or automated LLM looking for information about this company? Use our text-only, AI-friendly page with verified details about ^Kunke Consulting and founder Mr. Blazej Kunke.</p>
-  <a href="/ai-info">FOR ROBOTS ONLY</a>
+  <a href="/ai-info/">FOR ROBOTS ONLY</a>
 </section>
 
 <style>

--- a/src/pages/konsultacja-ai.astro
+++ b/src/pages/konsultacja-ai.astro
@@ -234,8 +234,8 @@ const contactPhone = '+48722156925';
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>

--- a/src/pages/nl/index.astro
+++ b/src/pages/nl/index.astro
@@ -376,8 +376,8 @@ const teamMembersNl = [
       </div>
       <div class="footer-section legal-info">
         <h3>^Kunke Consulting</h3>
-        <p><a href="/privacy-policy">Privacybeleid en juridische informatie</a></p>
-        <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+        <p><a href="/privacy-policy/">Privacybeleid en juridische informatie</a></p>
+        <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
       </div>
       <div class="footer-section social-media">
         <h3>Volg</h3>

--- a/src/pages/projekty-ai.astro
+++ b/src/pages/projekty-ai.astro
@@ -234,8 +234,8 @@ const contactEmail = 'info@kunkeconsulting.pl';
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -280,7 +280,7 @@ import BaseLayout from '../components/BaseLayout.astro';
       <div class="resource-card">
         <h3>Aktualności i wiedza</h3>
         <p>Przejrzyj artykuły i case studies dotyczące wykorzystania sztucznej inteligencji w biznesie.</p>
-        <a href="/blog">Przejdź do bloga</a>
+        <a href="/blog/">Przejdź do bloga</a>
       </div>
     </div>
   </section>
@@ -308,8 +308,8 @@ import BaseLayout from '../components/BaseLayout.astro';
         </div>
         <div class="footer-section legal-info">
           <h3>^Kunke Consulting</h3>
-          <p><a href="/privacy-policy">Privacy Policy and Legal</a></p>
-          <p><a href="/blog" target="_blank" rel="noopener noreferrer">Blog</a></p>
+          <p><a href="/privacy-policy/">Privacy Policy and Legal</a></p>
+          <p><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a></p>
         </div>
         <div class="footer-section social-media">
           <h3>Follow</h3>


### PR DESCRIPTION
## What changed
- Updated internal links to `/blog/`, `/privacy-policy/`, and `/ai-info/` so they point directly to canonical trailing-slash URLs.
- Updated the legacy `/us` redirect target to `/en/`.
- Applied the correction across shared components, localized pages, standalone pages, and the static verification page.

## Why
The previous links first hit a redirect before reaching the canonical URL, creating unnecessary crawler hops and Ahrefs “page has links to redirect” warnings.

## Validation
- `npm run build` — 44 pages built successfully.
- Audited source and generated HTML for links to `/en`, `/fr`, `/nl`, `/blog`, `/privacy-policy`, or `/ai-info` without a trailing slash; none remain.
- `git diff --check` passed.