### PR TITLE
Shorten page titles for search results

### DIFF
--- a/src/content/blog/ai-changing-consulting.md
+++ b/src/content/blog/ai-changing-consulting.md
@@ -1,5 +1,6 @@
 ---
 title: "Jak AI zmienia branżę konsultingową - Konsulting AI dla firm"
+seoTitle: "Konsulting AI: jak AI zmienia branżę konsultingową"
 description: "Odkrywamy wpływ sztucznej inteligencji na strategie biznesowe. Konsulting AI, doradztwo AI dla biznesu, implementacja AI w firmie."
 date: 2025-01-20
 tags: ["AI", "Konsulting AI", "Doradztwo AI", "AI dla biznesu", "Implementacja AI", "Szkolenia AI"]

--- a/src/content/blog/american-government-blocked-the-best-ai-model-now-what.md
+++ b/src/content/blog/american-government-blocked-the-best-ai-model-now-what.md
@@ -1,5 +1,6 @@
 ---
 title: "American Government Blocked the Best AI Model. Now What?"
+seoTitle: "US AI Model Block: What Businesses Should Know | ^Kunke"
 description: "Fable 5 and Mythos 5 disappeared overnight after a US export control directive. What the shutdown means for businesses, Europe, and AI strategy."
 date: 2026-06-13
 language: en

--- a/src/content/blog/amerykanski-rzad-zablokowal-najlepszy-model-ai-i-co-teraz.md
+++ b/src/content/blog/amerykanski-rzad-zablokowal-najlepszy-model-ai-i-co-teraz.md
@@ -1,5 +1,6 @@
 ---
 title: "Amerykański rząd zablokował najlepszy model AI. I co teraz?"
+seoTitle: "Blokada modelu AI: co oznacza dla polskich firm? | ^Kunke"
 description: "Fable 5 i Mythos 5 zniknęły po amerykańskiej dyrektywie eksportowej. Co ta blokada oznacza dla firm, Europy i strategii AI?"
 date: 2026-06-13
 author: "Błażej Kunke"

--- a/src/content/blog/czego-historia-bawelny-uczy-nas-o-sztucznej-inteligencji-i-kodzie.md
+++ b/src/content/blog/czego-historia-bawelny-uczy-nas-o-sztucznej-inteligencji-i-kodzie.md
@@ -1,5 +1,6 @@
 ---
 title: "Czego historia bawełny uczy nas o sztucznej inteligencji i kodzie"
+seoTitle: "AI i kod: czego uczy nas historia bawełny | ^Kunke"
 description: "Historia mechanizacji bawełny jako mapa do zrozumienia, jak AI najpierw wzmacnia, a potem reorganizuje pracę programistów i całych firm."
 date: 2026-03-06
 author: "Błażej Kunke"

--- a/src/content/blog/fable-5-polski-livestream.md
+++ b/src/content/blog/fable-5-polski-livestream.md
@@ -1,5 +1,6 @@
 ---
 title: "Fable 5 po polsku: dwa livestreamy dla początkujących"
+seoTitle: "Fable 5 po polsku: 2 livestreamy AI dla początkujących"
 description: "Zobacz nagrania dwóch polskojęzycznych livestreamów, podczas których testuję model Claude Fable 5 i pokazuję jego możliwości w praktyce."
 date: 2026-06-11
 author: "Błażej Kunke"

--- a/src/content/blog/grow-your-business.md
+++ b/src/content/blog/grow-your-business.md
@@ -1,5 +1,6 @@
 ---
 title: "4 sposoby na rozwój Twojego biznesu"
+seoTitle: "Rozwój biznesu: 4 sprawdzone sposoby dla firm | ^Kunke"
 description: "Proste strategie dla zrównoważonego wzrostu."
 date: 2024-05-25
 tags: ["Rozwój", "Strategia", "Wskazówki"]

--- a/src/content/blog/kunke-consulting-india-ai-impact-2026.md
+++ b/src/content/blog/kunke-consulting-india-ai-impact-2026.md
@@ -1,5 +1,6 @@
 ---
 title: "Kunke Consulting at India AI Impact 2026 in Warsaw"
+seoTitle: "India AI Impact 2026 Event in Warsaw | Kunke Consulting"
 description: "A brief note on Błażej Kunke’s attendance at the India AI Impact 2026 event at the Embassy of India in Warsaw."
 date: 2026-01-12
 language: en

--- a/src/content/blog/ponowne-wdrozenie-fable-5.md
+++ b/src/content/blog/ponowne-wdrozenie-fable-5.md
@@ -1,5 +1,6 @@
 ---
 title: "Ponowne wdrożenie Fable 5: co oznacza dla polskich przedsiębiorców?"
+seoTitle: "Fable 5 wraca: co to oznacza dla polskich firm? | ^Kunke"
 description: "Anthropic przywraca płacącym użytkownikom Claude dostęp do Fable 5, ale z limitami, przekierowaniami i krótkim oknem testowym do 7 lipca."
 date: 2026-07-01
 author: "Błażej Kunke"

--- a/src/content/blog/praktyczne-ai-w-rodzinnej-drukarni.md
+++ b/src/content/blog/praktyczne-ai-w-rodzinnej-drukarni.md
@@ -1,5 +1,6 @@
 ---
 title: "Praktyczne AI w rodzinnej drukarni: dwa wdrożenia, które można zrobić od razu"
+seoTitle: "AI w rodzinnej drukarni: dwa praktyczne wdrożenia AI"
 description: "Dwa konkretne wdrożenia AI dla polskiej firmy produkcyjnej: analiza danych sprzedażowych i odzyskiwanie zapomnianych klientów oraz agent AI do zarządzania skrzynką."
 date: 2026-07-06
 author: "Błażej Kunke"

--- a/src/content/blog/praktyczne-warsztaty-ai-polskie-firmy.md
+++ b/src/content/blog/praktyczne-warsztaty-ai-polskie-firmy.md
@@ -1,5 +1,6 @@
 ---
 title: "Jak praktyczne warsztaty AI przynoszą setki tysięcy złotych polskim firmom"
+seoTitle: "Warsztaty AI: realne oszczędności dla polskich firm"
 description: "Studium realnych rezultatów z warsztatów AI pokazujące, jak zespoły w polskich firmach generują setki tysięcy złotych oszczędności dzięki praktycznym wdrożeniom."
 date: 2025-02-10
 tags: ["AI", "Warsztaty", "ROI", "Automatyzacja", "Szkolenia"]

--- a/src/content/blog/selling-shovels-ai-gold-rush.md
+++ b/src/content/blog/selling-shovels-ai-gold-rush.md
@@ -1,5 +1,6 @@
 ---
 title: "Selling Shovels in the AI Gold Rush"
+seoTitle: "AI Implementation: Selling Shovels in the Gold Rush"
 description: "Why implementation expertise, not technology, is what SMEs actually need to capture the opportunities created by AI. A strategic framework from an AI consultant working with Polish and European businesses."
 date: 2026-02-06
 language: en

--- a/src/content/blog/signal-vs-noise-time-of-ai-hype.md
+++ b/src/content/blog/signal-vs-noise-time-of-ai-hype.md
@@ -1,5 +1,6 @@
 ---
 title: "Signal vs Noise In The Time of AI Hype"
+seoTitle: "AI Hype: How to Separate Signal from Noise | ^Kunke"
 description: "Reflections on cultivating signal, avoiding burnout, and staying grounded while the AI hype cycle rages on."
 date: 2025-03-12
 language: en

--- a/src/content/blog/spektrum-strategii-ai-szczery-przewodnik-dla-kadry-zarzadzajacej.md
+++ b/src/content/blog/spektrum-strategii-ai-szczery-przewodnik-dla-kadry-zarzadzajacej.md
@@ -1,5 +1,6 @@
 ---
 title: "Kompas AI dla firm: 7 strategii wprowadzenia sztucznej inteligencji"
+seoTitle: "Strategia AI dla firm: 7 podejść do wdrożenia | ^Kunke"
 description: "Od całkowitej bierności po pełne zaangażowanie. Co oznaczają poszczególne podejścia i kiedy mają sens."
 date: 2026-03-01
 author: "Błażej Kunke"

--- a/src/content/blog/the-ai-strategy-spectrum-a-honest-guide-for-senior-management.md
+++ b/src/content/blog/the-ai-strategy-spectrum-a-honest-guide-for-senior-management.md
@@ -1,5 +1,6 @@
 ---
 title: "The AI Strategy Spectrum: An Honest Guide for Senior Management"
+seoTitle: "AI Strategy: Seven Choices for Senior Management | ^Kunke"
 description: "From doing nothing to going all in, what each approach actually means, and when it makes sense."
 date: 2026-03-01
 language: en

--- a/src/content/blog/warsztaty-ai.md
+++ b/src/content/blog/warsztaty-ai.md
@@ -1,5 +1,6 @@
 ---
 title: "Warsztaty AI - Praktyczne szkolenia sztucznej inteligencji dla firm"
+seoTitle: "Warsztaty AI dla firm: praktyczne szkolenie | ^Kunke"
 description: "Kompleksowe szkolenia AI i warsztaty sztucznej inteligencji dla polskich firm. Kursy AI online, szkolenia ChatGPT, AI w Excel. Szkolenia AI Poznań, Warszawa, Łódź."
 date: 2025-01-15
 tags: ["AI", "Warsztaty", "Szkolenia AI", "Szkolenia sztucznej inteligencji", "Kursy AI", "ChatGPT", "AI Excel", "Szkolenia AI Poznań"]

--- a/src/content/blog/workshop-2025.md
+++ b/src/content/blog/workshop-2025.md
@@ -1,5 +1,6 @@
 ---
 title: "Warsztat 2025: Czego się spodziewać"
+seoTitle: "Warsztat AI 2025: czego może spodziewać się firma"
 description: "Podgląd naszego nadchodzącego warsztatu."
 date: 2025-01-10
 tags: ["Warsztat", "Wydarzenia", "2025"]

--- a/src/content/blog/you-could-spot-an-ai-image-in-2024.md
+++ b/src/content/blog/you-could-spot-an-ai-image-in-2024.md
@@ -1,5 +1,6 @@
 ---
 title: "You Could Spot an AI Image in 2024. You Probably Cannot in 2026."
+seoTitle: "AI Images in 2026: Why You Can No Longer Spot Them"
 description: "Why visual trust has changed: AI image models now generate photorealistic content that businesses can no longer reliably detect by eye."
 date: 2026-03-01
 language: en

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -5,6 +5,7 @@ const blog = defineCollection({
   schema: () =>
     z.object({
       title: z.string(),
+      seoTitle: z.string().optional(),
       description: z.string(),
       date: z.date(),
       language: z.enum(["pl", "en"]).default("pl"),

--- a/src/pages/ai-dla-firm.astro
+++ b/src/pages/ai-dla-firm.astro
@@ -3,7 +3,7 @@ import BaseLayout from '../components/BaseLayout.astro';
 ---
 
 <BaseLayout
-  title="AI dla firm | Konsultacje, szkolenia i projekty AI | ^Kunke Consulting"
+  title="AI dla firm: szkolenia, konsultacje, wdrożenia | ^Kunke"
   description="AI dla firm: konsultacja AI od 1399 PLN + VAT, szkolenia zespołów od 6000 PLN + VAT i projekty wdrożeniowe dopasowane do procesów Twojej organizacji."
   ogImage="/images/Kunke_Favicon.png"
 >

--- a/src/pages/ai-dla-ucznia-i-studenta-2025.astro
+++ b/src/pages/ai-dla-ucznia-i-studenta-2025.astro
@@ -4,7 +4,7 @@ import ExperienceSection from '../components/ExperienceSection.astro';
 ---
 
 <BaseLayout
-  title="AI dla ucznia i studenta 2025 – darmowy PDF | ^Kunke Consulting"
+  title="AI dla ucznia i studenta 2025 – darmowy PDF | ^Kunke"
   description="Bezpłatny przewodnik po sztucznej inteligencji dla rodziców, nauczycieli, uczniów i studentów."
   ogImage="/images/Kunke_Favicon.png"
 >
@@ -271,4 +271,3 @@ import ExperienceSection from '../components/ExperienceSection.astro';
     </div>
   </footer>
 </BaseLayout>
-

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -110,7 +110,7 @@ const articleSchema = {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/styles/global.css" />
-    <title>{post.data.title} | Blog - ^Kunke Consulting</title>
+    <title>{post.data.seoTitle ?? `${post.data.title} | Blog - ^Kunke Consulting`}</title>
     <meta name="description" content={post.data.description} />
 
     <!-- Canonical URL -->

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -21,7 +21,7 @@ const canonicalUrl = "https://kunkeconsulting.pl/blog/";
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/styles/global.css" />
-    <title>Blog | ^Kunke Consulting - Praktyczne szkolenia AI i doradztwo AI dla firm</title>
+    <title>Blog o praktycznym AI dla firm | ^Kunke Consulting</title>
     <meta name="description" content="Blog ^Kunke Consulting - najnowsze artykuły o praktycznych szkoleniach AI i doradztwie AI dla firm" />
     <link rel="canonical" href={canonicalUrl} />
     <link rel="alternate" hreflang="pl" href={canonicalUrl} />

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -35,7 +35,7 @@ const teamMembersEn = [
 ---
 
 <BaseLayout
-  title="AI Training and Implementation for Global Teams | ^Kunke Consulting"
+  title="AI Training and Implementation for Global Teams | ^Kunke"
   description="Practical AI training and implementation programs for international teams. Live online worldwide, with team training from $1,500 USD."
   ogImage="/images/Workshop2025.JPG"
 >

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -35,7 +35,7 @@ const teamMembersFr = [
 ---
 
 <BaseLayout
-  title="Implémentation de l'IA pour les entreprises en France | ^Kunke Consulting"
+  title="Implémentation IA pour les entreprises en France | ^Kunke"
   description="Programmes d’implémentation IA pour les équipes françaises : automatisation, solutions sur mesure et accompagnement sécurisé orienté résultats."
   ogImage="/images/Kunke_Favicon.png"
 >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import SiteFooter from '../components/SiteFooter.astro';
 ---
 
 <BaseLayout
-  title="Szkolenia AI dla firm | ^Kunke Consulting | Warsztaty i wdrożenia AI w Polsce i Europie"
+  title="Szkolenia AI dla firm i wdrożenia | ^Kunke Consulting"
   description="Warsztaty i szkolenia AI dla średnich przedsiębiorstw w Polsce i Europie. Praktyczne wdrożenia ChatGPT, automatyzacja procesów, doradztwo AI. Dla zespołów 20-500 osób. Średnia ocena 98%. Transformacja cyfrowa z gwarancją rezultatów."
   ogImage="/images/Workshop2025.JPG"
 >

--- a/src/pages/konsultacja-ai.astro
+++ b/src/pages/konsultacja-ai.astro
@@ -8,7 +8,7 @@ const contactPhone = '+48722156925';
 ---
 
 <BaseLayout
-  title="Konsultacje AI dla firm | 90-minutowa diagnoza AI | ^Kunke Consulting"
+  title="Konsultacje AI dla firm: diagnoza w 90 minut | ^Kunke"
   description="Konsultacje AI dla firm: 90-minutowa diagnoza potencjału, ryzyk i pierwszych kroków. Konkretne rekomendacje, notatka i transkrypcja spotkania."
   ogImage="/images/AI_strategy_2026.jpg"
 >

--- a/src/pages/konsulting-ai.astro
+++ b/src/pages/konsulting-ai.astro
@@ -6,7 +6,7 @@ import Testimonials from '../components/testimonials.astro';
 ---
 
 <BaseLayout 
-  title="Konsulting AI | Doradztwo AI dla firm | Implementacja sztucznej inteligencji | ^Kunke Consulting"
+  title="Konsulting AI dla firm i wdrożenia | ^Kunke Consulting"
   description="Profesjonalny konsulting AI i doradztwo w zakresie sztucznej inteligencji. Implementacja AI w firmie, strategia AI, wybór narzędzi AI. Doradztwo AI dla biznesu w Polsce."
   ogImage="/images/Kunke_Favicon.png"
 >

--- a/src/pages/nl/index.astro
+++ b/src/pages/nl/index.astro
@@ -35,7 +35,7 @@ const teamMembersNl = [
 ---
 
 <BaseLayout
-  title="AI-implementaties voor bedrijven in Nederland | ^Kunke Consulting"
+  title="AI-implementatie voor bedrijven in Nederland | ^Kunke"
   description="Praktische AI-implementaties en automatisering voor teams in Nederland. We leveren maatwerkoplossingen, begeleiden adoptie en bewaken dataveiligheid voor tastbare resultaten."
   ogImage="/images/Kunke_Favicon.png"
 >

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -4,7 +4,7 @@ import BaseLayout from '../components/BaseLayout.astro';
 ---
 
 <BaseLayout 
-  title="Polityka prywatności i informacje prawne | Błażej Kunke Consulting"
+  title="Polityka prywatności i dane osobowe | ^Kunke Consulting"
   description="Polityka prywatności i informacje prawne dotyczące usług Błażej Kunke Consulting"
 >
 

--- a/src/pages/projekty-ai.astro
+++ b/src/pages/projekty-ai.astro
@@ -5,7 +5,7 @@ const contactEmail = 'info@kunkeconsulting.pl';
 ---
 
 <BaseLayout
-  title="Projekty AI dla firm | Uporządkowane wdrożenia AI | ^Kunke Consulting"
+  title="Projekty AI dla firm: wdrożenia krok po kroku | ^Kunke"
   description="Współpraca projektowa i wdrożeniowa dla firm, które chcą przejść od zainteresowania AI do uporządkowanych działań: od identyfikacji use case'ów przez pilotaż po dalsze wsparcie."
   ogImage="/images/AI_strategy_2026.jpg"
 >

--- a/src/pages/szkolenia-ai-online.astro
+++ b/src/pages/szkolenia-ai-online.astro
@@ -6,7 +6,7 @@ import ContactForm from '../components/ContactForm.astro';
 ---
 
 <BaseLayout 
-  title="Praktyczne szkolenia AI online i doradztwo AI dla firm | ^Kunke Consulting"
+  title="Szkolenia AI online dla firm: praktyczny kurs | ^Kunke"
   description="Profesjonalne szkolenia AI online dla firm w Polsce. Praktyczne szkolenia AI, warsztaty ChatGPT i doradztwo AI dla firm. Elastyczne terminy, certyfikaty i wsparcie po szkoleniu."
   ogImage="/images/Kunke_Favicon.png"
 >

--- a/src/pages/szkolenia-ai-poznan.astro
+++ b/src/pages/szkolenia-ai-poznan.astro
@@ -7,7 +7,7 @@ import Testimonials from '../components/testimonials.astro';
 ---
 
 <BaseLayout 
-  title="Praktyczne szkolenia AI w Poznaniu i doradztwo AI dla firm | ^Kunke Consulting"
+  title="Szkolenia AI w Poznaniu dla firm | ^Kunke Consulting"
   description="Profesjonalne szkolenia AI w Poznaniu. Praktyczne szkolenia AI dla firm, warsztaty ChatGPT i doradztwo AI dla firm. AI training Poznań, AI dla biznesu."
   ogImage="/images/Kunke_Favicon.png"
 >

--- a/src/pages/szkolenia-ai.astro
+++ b/src/pages/szkolenia-ai.astro
@@ -7,7 +7,7 @@ import Testimonials from '../components/testimonials.astro';
 ---
 
 <BaseLayout
-  title="Praktyczne szkolenia AI i doradztwo AI dla firm | ^Kunke Consulting"
+  title="Szkolenia AI dla firm: praktyczne warsztaty | ^Kunke"
   description="Profesjonalne, praktyczne szkolenia AI i doradztwo AI dla firm w Polsce i Europie. Warsztaty ChatGPT, automatyzacja procesów i wdrożenia AI dla zespołów 20-200 osób. Szkolenia stacjonarne w Warszawie, Poznaniu i online. Certyfikat + wsparcie powdrożeniowe."
   ogImage="/images/Workshop2025.JPG"
 >


### PR DESCRIPTION
## What changed

- rewrote the 31 page titles that exceeded Ahrefs’ approximate 60-character threshold
- moved the main search phrase to the beginning of each revised title
- added a separate optional SEO title for blog posts, preserving the visible article headlines
- covered Polish service pages, the global English homepage, French and Dutch homepages, the blog index, and affected articles

## Why

Long titles were likely to be truncated in Google results, hiding relevant search phrases or the brand.

## Impact

All generated page titles are now 60 characters or fewer. Page content, visible headings, URLs, and descriptions are unchanged.

## Validation

- production build: passed (44 routes)
- Astro content/type check: 0 errors, 0 warnings (31 pre-existing hints)
- generated-title audit: 0 titles above 60 characters, down from 31
- staged diff whitespace check: passed