### PR TITLE
Translate homepage FAQ

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -192,65 +192,110 @@ const teamMembersEn = [
     <div class="faq-accordion">
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Is your AI training suitable for beginners?</h3>
+          <h3>Where should a company start with AI implementation?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Yes. My corporate AI training is designed for different experience levels. We start with the essentials and move towards more advanced business applications.</p>
+          <p>The most important first step is understanding the company’s specific needs and the opportunities AI can create. When we begin working with a new client, we assess their processes, identify where AI can deliver the greatest return, and prepare a first-step plan tailored to the company.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Where do the AI workshops take place?</h3>
+          <h3>What does AI consulting for companies include?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>I deliver AI sessions across Europe and beyond. I also offer online courses for maximum flexibility.</p>
+          <p>Our AI consulting includes a process audit, an AI implementation strategy, selection of the right tools, team training, and support with deploying AI solutions across the company.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>How long does a ChatGPT training last?</h3>
+          <h3>What does an AI implementation project look like, and how long does it take?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>The core ChatGPT workshop lasts one day, while comprehensive corporate AI programs can run for several days depending on your organization’s needs.</p>
+          <p>We begin by assessing needs and defining the strategy. We then map specific use cases, build the first AI assistants, and launch a pilot. The scope and timeline are agreed individually.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Do participants receive a certificate?</h3>
+          <h3>What about data security, GDPR, and the AI Act?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Yes. Every participant receives a certificate of completion and ongoing access to the training materials.</p>
+          <p>We treat data security as a priority. Our implementation projects account for compliance with GDPR and the AI Act. When needed, we work with attorney Justyna Surwiło-Rutkowska, our legal expert, legal counsel, and restructuring advisor with more than 10 years of experience.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>How can AI support my company?</h3>
+          <h3>What results and ROI can a company realistically achieve?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>AI speeds up reporting, delivers smarter analysis, saves time on repetitive work, and supports better data-driven decisions.</p>
+          <p>Results depend on the processes involved, but they usually include time saved on repetitive tasks, higher-quality materials, and better data-driven decisions. We describe a real example in our <a href="/Raport-AI-w-PragmatIQ.pdf">case study of an AI implementation at the PragmatIQ law firm in Poznań</a>.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>What does AI consulting include?</h3>
+          <h3>How can AI help my company?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>AI consulting includes a process audit, an implementation strategy, choosing the right tools, team training, and support while you deploy AI solutions.</p>
+          <p>AI is not just a tool for developers. It can also improve the everyday office work of sales, logistics, finance, and accounting teams. It helps automate repetitive tasks, accelerate reporting, produce more insightful analysis, and support better data-driven business decisions.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Can I order AI training for managers?</h3>
+          <h3>Where do you deliver AI training and projects?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Absolutely. I run dedicated AI sessions for managers focused on strategic adoption, leading teams in the age of AI, and decision-making with intelligent tools.</p>
+          <p>We are based in Poznań, but we work on-site across Poland and remotely with clients throughout Europe, in both Polish and English. We tailor the format to each team and its goals.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>How long are the AI workshops?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>A standard workshop consists of two five-hour days, for a total of 10 hours, and is based on real tasks from the team’s everyday work. We tailor the scope to the organization’s needs.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Is the AI training suitable for beginners?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Yes. Our corporate AI training is designed for different experience levels. We start with the fundamentals and gradually move to more advanced business applications of AI.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Will I receive a certificate after the AI training?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Yes. We can provide a certificate of completion to every participant, along with access to selected training materials.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>What is the difference between an AI agent and an AI assistant?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>An AI assistant responds to individual instructions under your control, while an AI agent independently plans and completes multi-step tasks using tools until it reaches the intended goal.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>What are the best croissants?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>St. Martin’s croissants—we are from Poznań, after all.</p>
         </div>
       </div>
     </div>

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -199,38 +199,47 @@ const teamMembersFr = [
     <div class="faq-accordion">
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Vos formations IA conviennent-elles aux débutants ?</h3>
+          <h3>Par où commencer pour mettre en œuvre l’IA dans une entreprise ?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Oui. Les ateliers sont structurés par niveau : nous posons les bases avant de passer à des cas métiers avancés.</p>
+          <p>La première étape essentielle consiste à comprendre les spécificités de l’entreprise et les possibilités offertes par l’IA. Lorsque nous commençons à travailler avec un nouveau client, nous analysons ses processus, identifions les domaines dans lesquels l’IA peut générer le meilleur retour et préparons un plan de démarrage adapté à son entreprise.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Où se déroulent les workshops IA ?</h3>
+          <h3>Que comprend le conseil en IA pour les entreprises ?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Nous intervenons à Paris, Lyon, Lille, Bruxelles, Genève… et également en ligne pour vos équipes réparties.</p>
+          <p>Notre conseil en IA comprend un audit des processus, une stratégie de mise en œuvre de l’IA, la sélection des outils adaptés, la formation de l’équipe et un accompagnement lors du déploiement de solutions d’IA dans l’entreprise.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Quelle est la durée d’une formation ChatGPT ?</h3>
+          <h3>Comment se déroule un projet de mise en œuvre de l’IA et combien de temps dure-t-il ?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Le module central se déroule sur une journée. Les parcours complets pour managers durent de deux à cinq jours selon vos besoins.</p>
+          <p>Nous commençons par analyser les besoins et définir la stratégie. Nous cartographions ensuite des cas d’usage concrets, créons les premiers assistants IA et lançons un projet pilote. Le périmètre et le calendrier sont définis individuellement.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Remettez-vous un certificat ?</h3>
+          <h3>Qu’en est-il de la sécurité des données, du RGPD et de l’AI Act ?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Chaque participant reçoit un certificat nominatif ainsi qu’un accès prolongé aux ressources pédagogiques.</p>
+          <p>La sécurité des données est une priorité pour nous. Nos projets de mise en œuvre tiennent compte de la conformité au RGPD et à l’AI Act. Si nécessaire, nous collaborons avec Maître Justyna Surwiło-Rutkowska, notre experte juridique, conseillère juridique et conseillère en restructuration, qui possède plus de 10 ans d’expérience.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Quels résultats et quel ROI une entreprise peut-elle réellement atteindre ?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Les résultats dépendent des processus concernés, mais ils se traduisent généralement par un gain de temps sur les tâches répétitives, une meilleure qualité des livrables et des décisions plus pertinentes fondées sur les données. Nous présentons un exemple concret dans notre <a href="/Raport-AI-w-PragmatIQ.pdf">étude de cas sur la mise en œuvre de l’IA au sein du cabinet d’avocats PragmatIQ à Poznań</a>.</p>
         </div>
       </div>
       <div class="faq-item">
@@ -239,25 +248,61 @@ const teamMembersFr = [
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Les assistants IA accélèrent les rapports, automatisent les analyses répétitives et fiabilisent vos décisions data-driven.</p>
+          <p>L’IA n’est pas réservée aux développeurs. Elle peut également améliorer le travail quotidien des équipes commerciales, logistiques, financières et comptables. Elle aide à automatiser les tâches répétitives, à accélérer la production de rapports, à créer des analyses plus pertinentes et à prendre de meilleures décisions fondées sur les données.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Que comprend une mission de conseil IA ?</h3>
+          <h3>Où organisez-vous vos formations et projets IA ?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Audit des processus, feuille de route, sélection d’outils, formation des équipes et accompagnement jusqu’au déploiement.</p>
+          <p>Nous sommes originaires de Poznań, mais nous travaillons sur site dans toute la Pologne et à distance avec des clients partout en Europe, en polonais et en anglais. Nous adaptons le format à chaque équipe et à ses objectifs.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Proposez-vous des ateliers pour les managers ?</h3>
+          <h3>Combien de temps durent les ateliers IA ?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Oui. Nous animons des sessions dédiées à la stratégie, au pilotage de projets IA et à la gouvernance responsable.</p>
+          <p>Un atelier standard se déroule sur deux journées de cinq heures, soit 10 heures au total, et s’appuie sur des tâches réelles du quotidien de l’équipe. Nous adaptons le contenu aux besoins de l’organisation.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Les formations IA conviennent-elles aux débutants ?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Oui. Nos formations IA pour les entreprises sont adaptées à différents niveaux d’expérience. Nous commençons par les fondamentaux avant de passer progressivement à des applications plus avancées de l’IA en entreprise.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Vais-je recevoir un certificat après la formation IA ?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Oui. Nous pouvons remettre un certificat de fin de formation à tous les participants, ainsi qu’un accès à une sélection de supports pédagogiques.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Quelle est la différence entre un agent IA et un assistant IA ?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Un assistant IA répond à des instructions individuelles sous votre contrôle, tandis qu’un agent IA planifie et exécute de manière autonome des tâches en plusieurs étapes à l’aide d’outils, jusqu’à atteindre l’objectif fixé.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Quels sont les meilleurs croissants ?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Les rogale świętomarcińskie, les croissants de la Saint-Martin : nous sommes de Poznań.</p>
         </div>
       </div>
     </div>

--- a/src/pages/nl/index.astro
+++ b/src/pages/nl/index.astro
@@ -199,65 +199,110 @@ const teamMembersNl = [
     <div class="faq-accordion">
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Is jullie AI-training geschikt voor beginners?</h3>
+          <h3>Waar begint u met de implementatie van AI in uw bedrijf?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Ja. Mijn AI-training voor bedrijven is gemaakt voor verschillende ervaringsniveaus. We starten met de basis en gaan daarna naar meer geavanceerde zakelijke toepassingen.</p>
+          <p>De belangrijkste eerste stap is inzicht krijgen in de specifieke kenmerken van uw bedrijf en de kansen die AI biedt. Wanneer we met een nieuwe klant aan de slag gaan, analyseren we de processen, bepalen we waar AI het meeste rendement kan opleveren en maken we een plan voor de eerste stappen dat op het bedrijf is afgestemd.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Waar vinden de AI-workshops plaats?</h3>
+          <h3>Wat omvat AI-advies voor bedrijven?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Ik verzorg AI-sessies in Nederland, in de rest van Europa en online. Zo kiest u de vorm die het beste bij uw team past.</p>
+          <p>Ons AI-advies omvat een procesaudit, een strategie voor AI-implementatie, de selectie van geschikte tools, training van het team en ondersteuning bij de invoering van AI-oplossingen binnen het bedrijf.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Hoe lang duurt een ChatGPT-training?</h3>
+          <h3>Hoe ziet een AI-implementatieproject eruit en hoelang duurt het?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>De kernworkshop rond ChatGPT duurt één dag. Uitgebreide AI-programma's voor bedrijven kunnen meerdere dagen beslaan, afhankelijk van de behoeften van uw organisatie.</p>
+          <p>We beginnen met een behoefteanalyse en het vaststellen van de strategie. Vervolgens brengen we concrete toepassingen in kaart, bouwen we de eerste AI-assistenten en starten we een pilot. De omvang en planning bepalen we voor ieder project afzonderlijk.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Ontvangen deelnemers een certificaat?</h3>
+          <h3>Hoe zit het met gegevensbeveiliging, de AVG en de AI Act?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Ja. Elke deelnemer ontvangt een certificaat van deelname en blijvende toegang tot het trainingsmateriaal.</p>
+          <p>Gegevensbeveiliging heeft voor ons de hoogste prioriteit. Bij implementatieprojecten houden we rekening met naleving van de AVG en de AI Act. Waar nodig werken we samen met jurist Justyna Surwiło-Rutkowska, onze juridisch expert, juridisch adviseur en herstructureringsadviseur met meer dan 10 jaar ervaring.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Hoe kan AI mijn bedrijf ondersteunen?</h3>
+          <h3>Welke resultaten en ROI kan een bedrijf realistisch behalen?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>AI versnelt rapportages, biedt slimmere analyses, bespaart tijd op repetitieve taken en ondersteunt betere datagedreven beslissingen.</p>
+          <p>De resultaten hangen af van de betrokken processen, maar meestal gaat het om tijdwinst bij repetitieve taken, materialen van hogere kwaliteit en betere beslissingen op basis van gegevens. Een praktijkvoorbeeld beschrijven we in onze <a href="/Raport-AI-w-PragmatIQ.pdf">case study over de AI-implementatie bij advocatenkantoor PragmatIQ in Poznań</a>.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Wat omvat AI-consultancy?</h3>
+          <h3>Hoe kan AI mijn bedrijf helpen?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>AI-consultancy omvat een procesaudit, implementatiestrategie, selectie van de juiste tools, training voor uw team en ondersteuning tijdens de uitrol van AI-oplossingen.</p>
+          <p>AI is niet alleen een hulpmiddel voor programmeurs. Het kan ook het dagelijkse kantoorwerk van teams in sales, logistiek, finance en accounting verbeteren. AI helpt repetitieve taken te automatiseren, rapportages te versnellen, betere analyses te maken en betere zakelijke beslissingen op basis van gegevens te nemen.</p>
         </div>
       </div>
       <div class="faq-item">
         <button class="faq-question" aria-expanded="false">
-          <h3>Kan ik AI-training voor managers aanvragen?</h3>
+          <h3>Waar verzorgen jullie AI-trainingen en -projecten?</h3>
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Zeker. Ik organiseer speciale AI-sessies voor managers gericht op strategische adoptie, leidinggeven in het AI-tijdperk en besluitvorming met intelligente tools.</p>
+          <p>We komen uit Poznań, maar werken op locatie in heel Polen en op afstand met klanten door heel Europa, in het Pools en Engels. We stemmen de vorm af op het team en de doelstellingen.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Hoelang duren de AI-workshops?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Een standaardworkshop bestaat uit twee dagen van vijf uur, in totaal 10 uur, en is gebaseerd op echte taken uit het dagelijkse werk van het team. We stemmen de inhoud af op de behoeften van de organisatie.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Zijn de AI-trainingen geschikt voor beginners?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Ja. Onze AI-trainingen voor bedrijven zijn afgestemd op verschillende ervaringsniveaus. We beginnen met de basis en gaan geleidelijk over naar geavanceerdere zakelijke toepassingen van AI.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Krijg ik na de AI-training een certificaat?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Ja. We kunnen alle deelnemers een certificaat van voltooiing en toegang tot een selectie van het trainingsmateriaal geven.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Wat is het verschil tussen een AI-agent en een AI-assistent?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Een AI-assistent reageert onder uw controle op afzonderlijke opdrachten. Een AI-agent plant en voert zelfstandig meerstapstaken uit met behulp van tools, totdat het beoogde doel is bereikt.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question" aria-expanded="false">
+          <h3>Wat zijn de beste croissants?</h3>
+          <span class="faq-icon">+</span>
+        </button>
+        <div class="faq-answer">
+          <p>Rogale świętomarcińskie natuurlijk — we komen uit Poznań.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What changed
- translated the complete 12-item homepage FAQ into American English, French, and Dutch
- preserved the same question order across every language version
- added the existing PragmatIQ case study PDF link to each translation
- kept the Polish homepage FAQ unchanged

## Why
All public language versions should provide the same current information about AI consulting, implementation projects, workshops, governance, ROI, and business use cases.

## Checks
- full Astro production build
- verified 12 FAQ questions and one report link on each translated page
- `git diff --check`