### PR TITLE
Fix localized FAQ report links

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -232,7 +232,7 @@ const teamMembersEn = [
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Results depend on the processes involved, but they usually include time saved on repetitive tasks, higher-quality materials, and better data-driven decisions. We describe a real example in our <a href="/Raport-AI-w-PragmatIQ.pdf">case study of an AI implementation at the PragmatIQ law firm in Poznań</a>.</p>
+          <p>Results depend on the processes involved, but they usually include time saved on repetitive tasks, higher-quality materials, and better data-driven decisions. We describe a real example in our <a href="/Kunke%20Consulting%20Use%20Case%20AI%20in%20a%20Law%20Firm%20English%20Translation%202025.pdf">case study of an AI implementation at the PragmatIQ law firm in Poznań</a>.</p>
         </div>
       </div>
       <div class="faq-item">

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -239,7 +239,7 @@ const teamMembersFr = [
           <span class="faq-icon">+</span>
         </button>
         <div class="faq-answer">
-          <p>Les résultats dépendent des processus concernés, mais ils se traduisent généralement par un gain de temps sur les tâches répétitives, une meilleure qualité des livrables et des décisions plus pertinentes fondées sur les données. Nous présentons un exemple concret dans notre <a href="/Raport-AI-w-PragmatIQ.pdf">étude de cas sur la mise en œuvre de l’IA au sein du cabinet d’avocats PragmatIQ à Poznań</a>.</p>
+          <p>Les résultats dépendent des processus concernés, mais ils se traduisent généralement par un gain de temps sur les tâches répétitives, une meilleure qualité des livrables et des décisions plus pertinentes fondées sur les données. Nous présentons un exemple concret dans notre <a href="/Transformation-IA-PragmatIQ-Expertise-et-Performance.pdf">étude de cas sur la mise en œuvre de l’IA au sein du cabinet d’avocats PragmatIQ à Poznań</a>.</p>
         </div>
       </div>
       <div class="faq-item">


### PR DESCRIPTION
## What changed
- English FAQ now links to the existing English PragmatIQ case-study PDF.
- French FAQ now links to the existing French PragmatIQ case-study PDF.

## Verification
- Confirmed both PDFs exist in `public/`.
- Production build passed (`npm run build`).

Follow-up to #163, which had already merged before its review feedback arrived.