### PR TITLE
Add /redesigned homepage preview

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import sitemap from '@astrojs/sitemap';
 
 const sitemapExcludedPaths = [
   '/thank-you',
+  '/redesigned',
   '/AIDlaFirm',
   '/aidlafirm',
   '/ai-excel',

--- a/src/pages/redesigned.astro
+++ b/src/pages/redesigned.astro
@@ -1,0 +1,1645 @@
+---
+// Redesign preview of the homepage — imported from the Claude Design project
+// "Homepage.dc.html" / "Homepage Mobile.dc.html".
+//
+// This page intentionally does NOT use BaseLayout: the redesign carries its own
+// type scale, palette and layout, which global.css would override (it forces
+// `section { width: min(90%, 72rem) }`, centred h2s and the Inter stack).
+// Kept noindex while it is a preview, and excluded from the sitemap in
+// astro.config.mjs. To promote it to the live homepage, move this markup into
+// index.astro and drop the robots meta.
+
+const siteUrl = Astro.site ?? new URL('https://kunkeconsulting.pl');
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
+
+const mailto = 'mailto:info@kunkeconsulting.pl?subject=Zapytanie%20o%20AI%20dla%20firmy';
+const mailtoOffer = 'mailto:info@kunkeconsulting.pl?subject=Zapytanie:%20AI%20dla%20firmy';
+
+const heroNotes = [
+  'Pracowałem 10 lat w korporacjach takich jak Franklin Templeton i McKinsey & Company',
+  'Warsztat: 2 dni × 5 h. Ćwiczenia na żywo, na danych zespołu.',
+  'Pracuję po polsku i po angielsku, stacjonarnie i zdalnie.'
+];
+
+const facts = [
+  { big: 'Stacjonarne', small: 'wierzymy, że szkolenia stacjonarne, nie online, dają najlepsze rezultaty' },
+  { big: '30 szkoleń', small: 'z AI oraz nowoczesnych narzędzi, od marca 2025' },
+  { big: '93%+', small: 'średnia ocena z ankiet poszkoleniowych' },
+  { big: '10–250', small: 'wielkość zespołów, z którymi pracuję' }
+];
+
+const steps = [
+  {
+    label: '01 — Diagnoza',
+    text: 'Rozmowy z działami, przegląd procesów, wskazanie miejsc o największym zwrocie. Bez zakupów narzędzi na tym etapie.'
+  },
+  {
+    label: '02 — Kompetencje',
+    text: 'Warsztaty na realnych zadaniach zespołu. Umiejętność, którą można użyć następnego dnia, nie po kwartale.'
+  },
+  {
+    label: '03 — Pilotaż',
+    text: 'Pierwsi asystenci AI w jednym procesie, mierzone efekty, konsultacja prawna (RODO, AI Act). Decyzja o skali na danych.'
+  }
+];
+
+const packages = [
+  {
+    tag: 'Pierwszy krok',
+    name: 'Szkolenie AI',
+    blurb: 'Dwa dni warsztatów, po których zespół używa AI w swojej pracy.',
+    items: [
+      'Praktyczne narzędzia AI',
+      'Inżynieria promptu',
+      'Obraz, dźwięk, wideo',
+      'Etyka, prawo, środowisko',
+      'Materiały PDF i certyfikat'
+    ],
+    price: 'od 6 000 zł + VAT'
+  },
+  {
+    tag: 'Program na miarę',
+    name: 'Wdrożenie AI',
+    blurb: 'Od badania potrzeb do pilotażu w wybranych procesach.',
+    items: [
+      'Badanie potrzeb zespołu',
+      'Strategia i mapa zastosowań',
+      'Pierwsi asystenci AI',
+      'Konsultacja prawna (RODO, AI Act)',
+      'Pilotaż i pomiar efektów'
+    ],
+    price: 'od 24 000 zł + VAT'
+  },
+  {
+    tag: 'Stała współpraca',
+    name: 'Projekty AI',
+    blurb: 'Dla firm, które chcą rozwijać AI dłużej niż jeden kwartał.',
+    items: [
+      'Asystenci AI dla zespołów',
+      'Cykliczne szkolenia',
+      'Wsparcie inżynieryjne',
+      'Wsparcie prawne',
+      'Doradztwo bieżące'
+    ],
+    price: 'wycena indywidualna'
+  }
+];
+
+const quotes = [
+  { text: 'Oprócz świetnego przekazania wiedzy zadbałeś też o przyjazną atmosferę.', who: 'Anna Majewska, SGB Leasing' },
+  {
+    text: 'Szkolenie pomoże mi zaoszczędzić kilkadziesiąt minut tygodniowo. Chętnie wezmę udział w bardziej zaawansowanym.',
+    who: 'Ankieta po szkoleniu, PDO Drukarnia'
+  },
+  { text: 'Dziękujemy za wspólny projekt.', who: 'Marta Ozga, CEO Ozga Group' }
+];
+
+const team = [
+  { name: 'Błażej Kunke', role: 'Założyciel, trener AI', img: '/images/team/blazej-kunke-team.jpg' },
+  { name: 'Bartosz Mikulski', role: 'Inżynier AI', img: '/images/team/bartosz-mikulski-july-2026-team.jpg' },
+  { name: 'Jan Kunke', role: 'Sprzedaż', img: '/images/team/jan-kunke-team.jpg' }
+];
+
+const faqs = [
+  {
+    q: 'Od czego zacząć wdrażanie AI w firmie?',
+    a: 'Od zrozumienia procesów, nie od zakupu narzędzi. Diagnozujemy, gdzie AI da największy zwrot, i układamy plan pierwszych kroków dopasowany do firmy.'
+  },
+  {
+    q: 'Ile trwa warsztat?',
+    a: 'Standardowo dwa dni po pięć godzin — dziesięć godzin pracy na realnych zadaniach zespołu. Zakres dopasowuję do organizacji.'
+  },
+  {
+    q: 'Co z RODO i AI Act?',
+    a: 'Zgodność uwzględniam w każdym wdrożeniu, a w sprawach prawnych współpracuję z radczynią prawną Justyną Surwiło-Rutkowską, doradczynią restrukturyzacyjną z ponad dziesięcioletnim doświadczeniem.'
+  },
+  {
+    q: 'Jakie efekty są realne?',
+    a: 'Zwykle: mniej czasu na zadaniach powtarzalnych, wyższa jakość materiałów, decyzje oparte na danych. Konkretne liczby z jednego wdrożenia opisałem w raporcie z PragmatIQ.'
+  },
+  {
+    q: 'Czy szkolenie jest dla początkujących?',
+    a: 'Tak. Zaczynamy od podstaw i przechodzimy do bardziej zaawansowanych zastosowań w tempie zespołu. Certyfikat dla uczestników na życzenie.'
+  },
+  { q: 'Najlepsze rogale?', a: 'Świętomarcińskie. Jesteśmy z Poznania.' }
+];
+---
+
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>Szkolenia i doradztwo AI dla firm | ^Kunke Consulting</title>
+  <meta
+    name="description"
+    content="Praktyczne szkolenia i wdrożenia AI dla średnich przedsiębiorstw. Zaczynamy od pracy, którą Twój zespół wykonuje dzisiaj. Poznań, cała Polska, stacjonarnie i zdalnie."
+  />
+  <meta name="robots" content="noindex, nofollow" />
+  <link rel="canonical" href={canonicalUrl} />
+
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/images/Kunke_Favicon.png" />
+
+  <style is:global>
+    :root {
+      --kc-bg: #faf9f6;
+      --kc-ink: #12201b;
+      --kc-green: #0a4731;
+      --kc-body: #3a4a43;
+      --kc-muted: #6b7b73;
+      --kc-card: #ffffff;
+      --kc-rule-08: rgba(10, 71, 49, 0.08);
+      --kc-rule-10: rgba(10, 71, 49, 0.1);
+      --kc-rule-12: rgba(10, 71, 49, 0.12);
+      --kc-rule-14: rgba(10, 71, 49, 0.14);
+      --kc-rule-18: rgba(10, 71, 49, 0.18);
+      --kc-rule-20: rgba(10, 71, 49, 0.2);
+      --kc-rule-25: rgba(10, 71, 49, 0.25);
+      --kc-rule-42: rgba(10, 71, 49, 0.42);
+      --kc-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      --kc-mono: ui-monospace, 'SF Mono', Menlo, monospace;
+      --kc-wrap: 1120px;
+      --kc-gut: 32px;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      /* Sticky header shouldn't cover anchored section headings. */
+      scroll-padding-top: 88px;
+    }
+
+    body {
+      margin: 0;
+      background: var(--kc-bg);
+      color: var(--kc-ink);
+      font-family: var(--kc-sans);
+      letter-spacing: -0.01em;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a {
+      color: var(--kc-green);
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: var(--kc-ink);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    ::selection {
+      background: var(--kc-green);
+      color: var(--kc-bg);
+    }
+
+    :focus-visible {
+      outline: 2px solid var(--kc-green);
+      outline-offset: 3px;
+      border-radius: 4px;
+    }
+
+    img {
+      max-width: 100%;
+    }
+
+    @keyframes kcRiseIn {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: none;
+      }
+    }
+
+    /* ---------- primitives ---------- */
+
+    .kc-wrap {
+      max-width: var(--kc-wrap);
+      margin: 0 auto;
+      padding-inline: var(--kc-gut);
+    }
+
+    .kc-eyebrow {
+      font-family: var(--kc-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--kc-muted);
+      margin: 0;
+    }
+
+    .kc-note {
+      font-family: var(--kc-mono);
+      font-size: 12px;
+      line-height: 1.7;
+      color: var(--kc-muted);
+      border-left: 1px solid var(--kc-rule-18);
+      padding-left: 18px;
+      margin: 0;
+    }
+
+    .kc-notes[hidden] {
+      display: none;
+    }
+
+    .kc-notes {
+      animation: kcRiseIn 400ms ease both;
+    }
+
+    .kc-btn {
+      display: inline-block;
+      border-radius: 999px;
+      background: var(--kc-green);
+      color: var(--kc-bg);
+      transition: background-color 200ms ease;
+    }
+
+    .kc-btn:hover {
+      background: var(--kc-ink);
+      color: var(--kc-bg);
+      text-decoration: none;
+    }
+
+    .kc-skip {
+      position: absolute;
+      left: -9999px;
+      top: 0;
+      z-index: 100;
+      background: var(--kc-green);
+      color: var(--kc-bg);
+      padding: 12px 18px;
+      border-radius: 0 0 8px 0;
+    }
+
+    .kc-skip:focus {
+      left: 0;
+      color: var(--kc-bg);
+    }
+
+    /* ---------- header ---------- */
+
+    .kc-header {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      background: rgba(250, 249, 246, 0.88);
+      backdrop-filter: saturate(140%) blur(12px);
+      border-bottom: 1px solid var(--kc-rule-10);
+    }
+
+    .kc-nav {
+      max-width: var(--kc-wrap);
+      margin: 0 auto;
+      padding: 16px var(--kc-gut);
+      display: flex;
+      align-items: center;
+      gap: 32px;
+    }
+
+    .kc-brand {
+      font-size: 17px;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--kc-green);
+    }
+
+    .kc-nav-links {
+      display: flex;
+      gap: 26px;
+      margin-left: auto;
+      font-size: 14px;
+    }
+
+    .kc-nav-links a {
+      color: var(--kc-body);
+    }
+
+    .kc-toggle {
+      font-family: var(--kc-mono);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 7px 12px;
+      border: 1px solid var(--kc-rule-25);
+      border-radius: 999px;
+      background: transparent;
+      color: var(--kc-green);
+      cursor: pointer;
+      transition: background-color 200ms ease, color 200ms ease, border-color 200ms ease;
+    }
+
+    .kc-toggle:hover {
+      background: var(--kc-green);
+      color: var(--kc-bg);
+      border-color: var(--kc-green);
+    }
+
+    .kc-nav .kc-btn {
+      font-size: 14px;
+      padding: 8px 16px;
+    }
+
+    /* ---------- hero ---------- */
+
+    .kc-hero {
+      max-width: var(--kc-wrap);
+      margin: 0 auto;
+      padding: 120px var(--kc-gut) 96px;
+      display: grid;
+      grid-template-columns: 1fr 300px;
+      gap: 64px;
+      align-items: end;
+    }
+
+    .kc-hero .kc-eyebrow {
+      margin-bottom: 28px;
+    }
+
+    .kc-hero h1 {
+      font-size: 68px;
+      line-height: 1.06;
+      font-weight: 500;
+      letter-spacing: -0.035em;
+      margin: 0;
+      max-width: 15em;
+      text-wrap: pretty;
+    }
+
+    .kc-lead {
+      font-size: 21px;
+      line-height: 1.55;
+      color: var(--kc-body);
+      max-width: 30em;
+      margin: 32px 0 40px;
+      text-wrap: pretty;
+    }
+
+    .kc-hero-cta {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+
+    .kc-hero-cta .kc-btn {
+      font-size: 16px;
+      padding: 15px 26px;
+    }
+
+    .kc-hero-cta .kc-link-quiet {
+      font-size: 16px;
+      color: var(--kc-body);
+    }
+
+    .kc-hero-notes {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      padding-bottom: 8px;
+    }
+
+    .kc-hero-notes .kc-note {
+      font-size: 12px;
+      line-height: 1.6;
+    }
+
+    /* ---------- facts band ---------- */
+
+    .kc-facts {
+      border-top: 1px solid var(--kc-rule-10);
+      border-bottom: 1px solid var(--kc-rule-10);
+      background: rgba(10, 71, 49, 0.02);
+    }
+
+    .kc-facts-grid {
+      max-width: var(--kc-wrap);
+      margin: 0 auto;
+      padding: 40px var(--kc-gut);
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 32px;
+    }
+
+    .kc-fact-big {
+      font-size: 32px;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+      margin: 0;
+      color: var(--kc-green);
+    }
+
+    .kc-fact-small {
+      font-size: 13px;
+      line-height: 1.45;
+      color: var(--kc-muted);
+      margin: 6px 0 0;
+    }
+
+    /* ---------- shared section shell ---------- */
+
+    .kc-section {
+      max-width: var(--kc-wrap);
+      margin: 0 auto;
+      padding: 112px var(--kc-gut) 0;
+    }
+
+    .kc-split {
+      display: grid;
+      grid-template-columns: 200px 1fr;
+      gap: 64px;
+    }
+
+    .kc-split > .kc-eyebrow {
+      margin-top: 8px;
+    }
+
+    .kc-h2 {
+      font-size: 40px;
+      line-height: 1.15;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+      margin: 0;
+      max-width: 20em;
+      text-wrap: pretty;
+    }
+
+    /* ---------- process ---------- */
+
+    .kc-steps {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 40px;
+      margin-top: 56px;
+    }
+
+    .kc-step {
+      border-top: 1px solid var(--kc-rule-20);
+      padding-top: 20px;
+    }
+
+    .kc-step-label {
+      font-family: var(--kc-mono);
+      font-size: 11px;
+      color: var(--kc-muted);
+      margin: 0 0 12px;
+    }
+
+    .kc-step-text {
+      font-size: 16px;
+      line-height: 1.6;
+      color: var(--kc-body);
+      margin: 0;
+    }
+
+    .kc-note-block {
+      margin-top: 36px;
+      max-width: 44em;
+    }
+
+    /* Notes that sit on their own, without the marginal rule. */
+    .kc-note-plain {
+      border-left: none;
+      padding-left: 0;
+      margin-top: 28px;
+      max-width: 52em;
+    }
+
+    /* ---------- offer ---------- */
+
+    .kc-offer-head {
+      display: grid;
+      grid-template-columns: 200px 1fr;
+      gap: 64px;
+      margin-bottom: 48px;
+    }
+
+    .kc-cards {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+
+    .kc-card {
+      background: var(--kc-card);
+      border: 1px solid var(--kc-rule-12);
+      border-radius: 18px;
+      padding: 32px 28px 28px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      transition: border-color 200ms ease, transform 200ms ease;
+    }
+
+    .kc-card:hover {
+      border-color: var(--kc-rule-42);
+      transform: translateY(-2px);
+    }
+
+    .kc-card-tag {
+      font-family: var(--kc-mono);
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--kc-muted);
+      margin: 0 0 14px;
+    }
+
+    .kc-card h3 {
+      font-size: 24px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      margin: 0 0 8px;
+    }
+
+    .kc-card-blurb {
+      font-size: 15px;
+      line-height: 1.55;
+      color: var(--kc-body);
+      margin: 0;
+    }
+
+    .kc-card-items {
+      display: flex;
+      flex-direction: column;
+      gap: 9px;
+      margin-top: auto;
+      padding: 0;
+      list-style: none;
+    }
+
+    .kc-card-items li {
+      font-size: 14px;
+      line-height: 1.45;
+      color: var(--kc-body);
+      padding-left: 16px;
+      border-left: 1px solid var(--kc-rule-18);
+    }
+
+    .kc-card-foot {
+      border-top: 1px solid var(--kc-rule-12);
+      padding-top: 18px;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .kc-price {
+      font-size: 17px;
+      font-weight: 500;
+      margin: 0;
+      color: var(--kc-green);
+    }
+
+    .kc-card-foot a {
+      font-size: 14px;
+      white-space: nowrap;
+    }
+
+    /* ---------- case study ---------- */
+
+    .kc-case {
+      max-width: var(--kc-wrap);
+      margin: 112px auto 0;
+      padding-inline: var(--kc-gut);
+    }
+
+    .kc-case-panel {
+      background: var(--kc-green);
+      color: var(--kc-bg);
+      border-radius: 22px;
+      overflow: hidden;
+      display: grid;
+      grid-template-columns: 1.15fr 1fr;
+    }
+
+    .kc-case-body {
+      padding: 56px 48px;
+    }
+
+    .kc-case-body .kc-eyebrow {
+      color: rgba(250, 249, 246, 0.6);
+      margin-bottom: 24px;
+    }
+
+    .kc-case-body h2 {
+      font-size: 36px;
+      line-height: 1.15;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+      margin: 0 0 20px;
+      max-width: 18em;
+      text-wrap: pretty;
+    }
+
+    .kc-case-body p {
+      font-size: 17px;
+      line-height: 1.6;
+      color: rgba(250, 249, 246, 0.78);
+      margin: 0 0 32px;
+      max-width: 32em;
+    }
+
+    .kc-case-cta {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .kc-btn-light {
+      display: inline-block;
+      font-size: 15px;
+      padding: 13px 22px;
+      border-radius: 999px;
+      background: var(--kc-bg);
+      color: var(--kc-green);
+      transition: background-color 200ms ease;
+    }
+
+    .kc-btn-light:hover {
+      background: #ffffff;
+      color: var(--kc-green);
+      text-decoration: none;
+    }
+
+    .kc-btn-ghost {
+      display: inline-block;
+      font-size: 15px;
+      padding: 13px 22px;
+      border-radius: 999px;
+      border: 1px solid rgba(250, 249, 246, 0.35);
+      color: var(--kc-bg);
+      transition: border-color 200ms ease;
+    }
+
+    .kc-btn-ghost:hover {
+      border-color: var(--kc-bg);
+      color: var(--kc-bg);
+      text-decoration: none;
+    }
+
+    .kc-case-media {
+      background: rgba(250, 249, 246, 0.06);
+      min-height: 340px;
+    }
+
+    .kc-case-media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+      filter: saturate(92%);
+    }
+
+    /* ---------- about ---------- */
+
+    .kc-about {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 72px;
+      align-items: center;
+    }
+
+    .kc-about-media {
+      border-radius: 18px;
+      overflow: hidden;
+      background: rgba(10, 71, 49, 0.06);
+      aspect-ratio: 4 / 5;
+    }
+
+    .kc-about-media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .kc-about-body .kc-eyebrow {
+      margin-bottom: 24px;
+    }
+
+    .kc-about-body h2 {
+      font-size: 36px;
+      line-height: 1.18;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+      margin: 0 0 24px;
+      text-wrap: pretty;
+    }
+
+    .kc-about-body p:not(.kc-note):not(.kc-eyebrow) {
+      font-size: 17px;
+      line-height: 1.65;
+      color: var(--kc-body);
+      margin: 0 0 18px;
+    }
+
+    .kc-about-body p:not(.kc-note):not(.kc-eyebrow):last-of-type {
+      margin-bottom: 28px;
+    }
+
+    /* ---------- quotes ---------- */
+
+    .kc-quotes {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+
+    .kc-quote {
+      border-top: 1px solid var(--kc-rule-20);
+      padding-top: 24px;
+      margin: 0;
+    }
+
+    .kc-quote p {
+      font-size: 17px;
+      line-height: 1.6;
+      margin: 0 0 20px;
+      color: var(--kc-ink);
+      text-wrap: pretty;
+    }
+
+    .kc-quote figcaption {
+      font-size: 13px;
+      color: var(--kc-muted);
+    }
+
+    /* ---------- team ---------- */
+
+    .kc-team-h2 {
+      font-size: 32px;
+      line-height: 1.2;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+      margin: 0 0 40px;
+      max-width: 22em;
+    }
+
+    .kc-team {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+
+    .kc-team-photo {
+      border-radius: 14px;
+      overflow: hidden;
+      background: rgba(10, 71, 49, 0.06);
+      aspect-ratio: 1 / 1;
+      margin-bottom: 16px;
+    }
+
+    .kc-team-photo img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .kc-team-name {
+      font-size: 17px;
+      font-weight: 500;
+      margin: 0 0 4px;
+    }
+
+    .kc-team-role {
+      font-size: 14px;
+      color: var(--kc-muted);
+      margin: 0;
+    }
+
+    /* ---------- faq ---------- */
+
+    .kc-faq {
+      border-top: 1px solid var(--kc-rule-14);
+    }
+
+    .kc-faq-item {
+      border-bottom: 1px solid var(--kc-rule-14);
+    }
+
+    /* The heading only carries semantics; the button does the styling. */
+    .kc-faq-heading {
+      margin: 0;
+      font: inherit;
+    }
+
+    .kc-faq-q {
+      width: 100%;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 24px;
+      text-align: left;
+      padding: 22px 0;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 19px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      color: var(--kc-ink);
+      transition: color 200ms ease;
+    }
+
+    .kc-faq-q:hover {
+      color: var(--kc-green);
+    }
+
+    .kc-faq-sign {
+      font-family: var(--kc-mono);
+      font-size: 14px;
+      color: var(--kc-muted);
+    }
+
+    .kc-faq-a {
+      font-size: 16px;
+      line-height: 1.65;
+      color: var(--kc-body);
+      margin: 0;
+      padding: 0 25% 26px 0;
+      max-width: 40em;
+    }
+
+    .kc-faq-a[hidden] {
+      display: none;
+    }
+
+    /* ---------- contact ---------- */
+
+    .kc-contact {
+      max-width: var(--kc-wrap);
+      margin: 112px auto 0;
+      padding: 0 var(--kc-gut) 96px;
+    }
+
+    .kc-contact-inner {
+      border-top: 1px solid var(--kc-rule-20);
+      padding-top: 56px;
+      display: grid;
+      grid-template-columns: 1.2fr 1fr;
+      gap: 64px;
+      align-items: start;
+    }
+
+    .kc-contact h2 {
+      font-size: 44px;
+      line-height: 1.1;
+      font-weight: 500;
+      letter-spacing: -0.035em;
+      margin: 0 0 24px;
+      max-width: 18em;
+      text-wrap: pretty;
+    }
+
+    .kc-contact .kc-btn {
+      font-size: 20px;
+      padding: 17px 30px;
+    }
+
+    .kc-contact .kc-note {
+      margin-top: 28px;
+      border-left: none;
+      padding-left: 0;
+    }
+
+    .kc-contact-details {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      font-size: 15px;
+      color: var(--kc-body);
+    }
+
+    .kc-contact-details p {
+      margin: 0;
+    }
+
+    .kc-contact-details a {
+      color: var(--kc-body);
+    }
+
+    /* ---------- footer ---------- */
+
+    .kc-footer {
+      border-top: 1px solid var(--kc-rule-10);
+      background: rgba(10, 71, 49, 0.02);
+    }
+
+    .kc-footer-inner {
+      max-width: var(--kc-wrap);
+      margin: 0 auto;
+      padding: 32px;
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      flex-wrap: wrap;
+      font-size: 13px;
+      color: var(--kc-muted);
+    }
+
+    .kc-footer-inner p {
+      margin: 0;
+    }
+
+    .kc-footer-links {
+      display: flex;
+      gap: 20px;
+      margin-left: auto;
+      flex-wrap: wrap;
+    }
+
+    .kc-footer-links a {
+      color: var(--kc-muted);
+    }
+
+    /* ---------- tablet ---------- */
+
+    @media (max-width: 900px) {
+      .kc-hero {
+        grid-template-columns: 1fr;
+        gap: 36px;
+        padding-top: 72px;
+        padding-bottom: 64px;
+        align-items: start;
+      }
+
+      .kc-hero h1 {
+        font-size: 48px;
+      }
+
+      .kc-split,
+      .kc-offer-head {
+        grid-template-columns: 1fr;
+        gap: 20px;
+      }
+
+      .kc-section {
+        padding-top: 72px;
+      }
+
+      .kc-h2,
+      .kc-about-body h2,
+      .kc-case-body h2 {
+        font-size: 32px;
+      }
+
+      .kc-steps {
+        grid-template-columns: 1fr;
+        gap: 24px;
+        margin-top: 32px;
+      }
+
+      .kc-cards,
+      .kc-quotes,
+      .kc-team {
+        grid-template-columns: 1fr;
+      }
+
+      /* Four stats across is too tight here: the labels wrap unevenly. */
+      .kc-facts-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 28px 32px;
+      }
+
+      .kc-case {
+        margin-top: 72px;
+      }
+
+      .kc-case-panel {
+        grid-template-columns: 1fr;
+      }
+
+      /* Design puts the photo above the copy on narrow screens. */
+      .kc-case-media {
+        order: -1;
+        min-height: 0;
+      }
+
+      .kc-case-media img {
+        height: 180px;
+      }
+
+      .kc-case-body {
+        padding: 26px 24px 24px;
+      }
+
+      .kc-about {
+        grid-template-columns: 1fr;
+        gap: 24px;
+      }
+
+      .kc-about-media {
+        aspect-ratio: 4 / 3;
+      }
+
+      .kc-faq-a {
+        padding-right: 0;
+      }
+
+      .kc-contact {
+        margin-top: 72px;
+        padding-bottom: 64px;
+      }
+
+      .kc-contact-inner {
+        grid-template-columns: 1fr;
+        gap: 40px;
+        padding-top: 40px;
+      }
+
+      .kc-contact h2 {
+        font-size: 32px;
+      }
+    }
+
+    /* ---------- phone ---------- */
+
+    @media (max-width: 600px) {
+      :root {
+        --kc-gut: 20px;
+      }
+
+      .kc-nav {
+        gap: 12px;
+      }
+
+      /* Anchor nav is dropped on phones, as in the mobile design. */
+      .kc-nav-links {
+        display: none;
+      }
+
+      .kc-brand {
+        font-size: 15px;
+      }
+
+      .kc-toggle {
+        margin-left: auto;
+        font-size: 10px;
+        min-height: 44px;
+        padding: 0 14px;
+      }
+
+      .kc-nav .kc-btn {
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+      }
+
+      .kc-hero {
+        padding-top: 40px;
+        padding-bottom: 36px;
+      }
+
+      .kc-eyebrow {
+        font-size: 10px;
+      }
+
+      .kc-hero h1 {
+        font-size: 36px;
+        line-height: 1.08;
+      }
+
+      .kc-lead {
+        font-size: 17px;
+        margin: 20px 0 28px;
+      }
+
+      /* Full-width tap targets on phones. */
+      .kc-hero-cta {
+        display: block;
+      }
+
+      .kc-hero-cta .kc-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 52px;
+        padding: 0 20px;
+        text-align: center;
+      }
+
+      .kc-hero-cta .kc-link-quiet {
+        display: inline-block;
+        margin-top: 16px;
+      }
+
+      .kc-hero-notes {
+        margin-top: 28px;
+        padding-bottom: 0;
+      }
+
+      .kc-facts-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+        padding-block: 28px;
+      }
+
+      .kc-fact-big {
+        font-size: 22px;
+      }
+
+      .kc-fact-small {
+        font-size: 12px;
+      }
+
+      .kc-section {
+        padding-top: 44px;
+      }
+
+      .kc-h2,
+      .kc-about-body h2,
+      .kc-case-body h2,
+      .kc-contact h2 {
+        font-size: 26px;
+      }
+
+      .kc-team-h2 {
+        font-size: 24px;
+        margin-bottom: 24px;
+      }
+
+      .kc-card {
+        border-radius: 16px;
+        padding: 22px 20px;
+        gap: 16px;
+      }
+
+      .kc-card h3 {
+        font-size: 20px;
+      }
+
+      .kc-card-foot a {
+        display: flex;
+        align-items: center;
+        min-height: 44px;
+      }
+
+      .kc-case {
+        margin-top: 44px;
+      }
+
+      .kc-case-panel {
+        border-radius: 20px;
+      }
+
+      .kc-case-cta {
+        display: block;
+      }
+
+      .kc-case-cta .kc-btn-light,
+      .kc-case-cta .kc-btn-ghost {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 48px;
+        padding: 0 20px;
+      }
+
+      .kc-case-cta .kc-btn-ghost {
+        margin-top: 12px;
+      }
+
+      /* Team collapses to a compact list, as in the mobile design. */
+      .kc-team {
+        gap: 16px;
+      }
+
+      .kc-team-member {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .kc-team-photo {
+        width: 68px;
+        flex-shrink: 0;
+        border-radius: 12px;
+        margin-bottom: 0;
+      }
+
+      .kc-team-name {
+        font-size: 16px;
+      }
+
+      .kc-team-role {
+        font-size: 13px;
+      }
+
+      .kc-faq-q {
+        font-size: 16px;
+        gap: 16px;
+        min-height: 56px;
+        padding: 16px 0;
+      }
+
+      .kc-faq-a {
+        font-size: 15px;
+        padding-bottom: 20px;
+      }
+
+      .kc-contact {
+        margin-top: 44px;
+      }
+
+      .kc-contact .kc-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 52px;
+        font-size: 16px;
+        padding: 0 20px;
+      }
+
+      .kc-footer-inner {
+        padding: 24px 20px 56px;
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .kc-footer-links {
+        margin-left: 0;
+        gap: 18px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html {
+        scroll-behavior: auto;
+      }
+
+      .kc-notes {
+        animation: none;
+      }
+
+      .kc-card,
+      .kc-btn,
+      .kc-toggle,
+      .kc-faq-q,
+      .kc-btn-light,
+      .kc-btn-ghost {
+        transition: none;
+      }
+
+      .kc-card:hover {
+        transform: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="kc-skip" href="#top">Przejdź do treści</a>
+
+  <header class="kc-header">
+    <nav class="kc-nav" aria-label="Główna nawigacja">
+      <a href="#top" class="kc-brand">^Kunke Consulting</a>
+      <div class="kc-nav-links">
+        <a href="#oferta">Oferta</a>
+        <a href="#wdrozenie">Wdrożenie</a>
+        <a href="#zespol">Zespół</a>
+        <a href="#pytania">Pytania</a>
+      </div>
+      <button
+        type="button"
+        class="kc-toggle"
+        id="kc-notes-toggle"
+        aria-pressed="true"
+        title="Pokaż przypisy i liczby na marginesie"
+      >
+        detale
+      </button>
+      <a href="mailto:info@kunkeconsulting.pl" class="kc-btn">Napisz</a>
+    </nav>
+  </header>
+
+  <main id="top">
+    <section class="kc-hero">
+      <div>
+        <p class="kc-eyebrow">AI dla Twojej firmy · Poznań · Polska</p>
+        <h1>Praktyczne szkolenia i doradztwo AI dla biznesu.</h1>
+        <p class="kc-lead">
+          Szkolenia i wdrożenia dla średnich przedsiębiorstw. Zaczynamy od pracy, którą Twój zespół
+          wykonuje dzisiaj. Skupiamy się na praktyce. Szkolimy stacjonarnie. Obiecujemy mało i
+          dostarczamy dużo.
+        </p>
+        <div class="kc-hero-cta">
+          <a href={mailto} class="kc-btn">info@kunkeconsulting.pl</a>
+          <a href="#wdrozenie" class="kc-link-quiet">Zobacz, jak pracuję</a>
+        </div>
+      </div>
+      <div class="kc-notes kc-hero-notes" data-kc-notes>
+        {heroNotes.map((note) => <p class="kc-note">{note}</p>)}
+      </div>
+    </section>
+
+    <section class="kc-facts" aria-label="^Kunke Consulting w liczbach">
+      <div class="kc-facts-grid">
+        {
+          facts.map((fact) => (
+            <div>
+              <p class="kc-fact-big">{fact.big}</p>
+              <p class="kc-fact-small">{fact.small}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <section id="wdrozenie" class="kc-section kc-split">
+      <p class="kc-eyebrow">Jak pracuję</p>
+      <div>
+        <h2 class="kc-h2">Najpierw poznaję Wasz proces. Potem dobieram narzędzie.</h2>
+        <div class="kc-steps">
+          {
+            steps.map((step) => (
+              <div class="kc-step">
+                <p class="kc-step-label">{step.label}</p>
+                <p class="kc-step-text">{step.text}</p>
+              </div>
+            ))
+          }
+        </div>
+        <div class="kc-notes" data-kc-notes>
+          <p class="kc-note kc-note-block">
+            Przypis: mierzymy realnie oszczędzony czas, nie entuzjazm.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section id="oferta" class="kc-section">
+      <div class="kc-offer-head">
+        <p class="kc-eyebrow">Oferta</p>
+        <h2 class="kc-h2">Trzy sposoby na start.</h2>
+      </div>
+      <div class="kc-cards">
+        {
+          packages.map((pkg) => (
+            <div class="kc-card">
+              <div>
+                <p class="kc-card-tag">{pkg.tag}</p>
+                <h3>{pkg.name}</h3>
+                <p class="kc-card-blurb">{pkg.blurb}</p>
+              </div>
+              <ul class="kc-card-items">
+                {pkg.items.map((item) => <li>{item}</li>)}
+              </ul>
+              <div class="kc-card-foot">
+                <p class="kc-price">{pkg.price}</p>
+                <a href={mailtoOffer} aria-label={`Zapytaj o ${pkg.name}`}>Zapytaj →</a>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+      <div class="kc-notes" data-kc-notes>
+        <p class="kc-note kc-note-plain">
+          Jeżeli nie jesteś pewien: zacznijmy od jednego szkolenia.
+        </p>
+      </div>
+    </section>
+
+    <section class="kc-case" aria-labelledby="kc-case-title">
+      <div class="kc-case-panel">
+        <div class="kc-case-body">
+          <p class="kc-eyebrow">Case study · PDF, 13 stron</p>
+          <h2 id="kc-case-title">Pół roku AI w kancelarii PragmatIQ w Poznaniu</h2>
+          <p>
+            11 osób, 8 projektów, dział po dziale: finanse, księgowość, administracja, marketing,
+            zespoły merytoryczne. Razem z tym, co zostało w pilotażu i dlaczego.
+          </p>
+          <div class="kc-case-cta">
+            <a href="/Raport-AI-w-PragmatIQ.pdf" class="kc-btn-light">Pobierz raport</a>
+            <a
+              href="https://pragmatiq.pl/aktualnosci/wydalismy-raport-ai-w-pragmatiq"
+              class="kc-btn-ghost"
+              rel="noopener"
+            >
+              Perspektywa klienta
+            </a>
+          </div>
+        </div>
+        <div class="kc-case-media">
+          <picture>
+            <source
+              srcset="/images/Workshop2025-mobile.webp 600w, /images/Workshop2025.webp 1200w"
+              sizes="(max-width: 900px) 100vw, 45vw"
+              type="image/webp"
+            />
+            <img
+              src="/images/Workshop2025.JPG"
+              alt="Uczestnicy praktycznego szkolenia AI podczas ćwiczeń na żywo"
+              width="1740"
+              height="1305"
+              loading="lazy"
+              decoding="async"
+            />
+          </picture>
+        </div>
+      </div>
+    </section>
+
+    <section class="kc-section kc-about" aria-labelledby="kc-about-title">
+      <div class="kc-about-media">
+        <picture>
+          <source srcset="/images/Omnie.webp" type="image/webp" />
+          <img
+            src="/images/Omnie.jpg"
+            alt="Błażej Kunke, założyciel ^Kunke Consulting"
+            width="702"
+            height="1024"
+            loading="lazy"
+            decoding="async"
+          />
+        </picture>
+      </div>
+      <div class="kc-about-body">
+        <p class="kc-eyebrow">O mnie</p>
+        <h2 id="kc-about-title">Zmiana już się dzieje. Dla Twojej firmy to szansa.</h2>
+        <p>
+          Po dziesięciu latach w globalnych korporacjach takich jak Franklin Templeton Investments,
+          McKinsey &amp; Company założyłem własne studio. Interesuje mnie to, jak technologia działa
+          naprawdę: co dzieje się pod interfejsem, gdzie są jej granice i co z tego wynika dla
+          zespołu w poniedziałek rano.
+        </p>
+        <p>
+          Dlatego nie sprzedaję automatyzacji wszystkiego. Obiecuję dokładnie tyle, ile potrafimy
+          dowieźć — i staram się dostarczyć więcej.
+        </p>
+        <div class="kc-notes" data-kc-notes>
+          <p class="kc-note">
+            Przypis: kiedy używam słów „zawsze”, „nigdy” i „bezpłatnie”, mam je na myśli dosłownie.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="kc-section" aria-label="Opinie klientów">
+      <div class="kc-quotes">
+        {
+          quotes.map((quote) => (
+            <figure class="kc-quote">
+              <p>{quote.text}</p>
+              <figcaption>{quote.who}</figcaption>
+            </figure>
+          ))
+        }
+      </div>
+    </section>
+
+    <section id="zespol" class="kc-section kc-split">
+      <p class="kc-eyebrow">Zespół</p>
+      <div>
+        <h2 class="kc-team-h2">Trener, inżynier, sprzedawca.</h2>
+        <div class="kc-team">
+          {
+            team.map((person) => (
+              <div class="kc-team-member">
+                <div class="kc-team-photo">
+                  <picture>
+                    <source srcset={person.img.replace(/\.jpg$/, '.webp')} type="image/webp" />
+                    <img
+                      src={person.img}
+                      alt={`${person.name} — ${person.role}`}
+                      width="720"
+                      height="900"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  </picture>
+                </div>
+                <div>
+                  <p class="kc-team-name">{person.name}</p>
+                  <p class="kc-team-role">{person.role}</p>
+                </div>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <section id="pytania" class="kc-section kc-split">
+      <p class="kc-eyebrow">Pytania</p>
+      <div class="kc-faq">
+        {
+          faqs.map((faq, i) => (
+            <div class="kc-faq-item">
+              <h3 class="kc-faq-heading">
+                <button
+                  type="button"
+                  class="kc-faq-q"
+                  aria-expanded={i === 0 ? 'true' : 'false'}
+                  aria-controls={`kc-faq-a-${i}`}
+                  id={`kc-faq-q-${i}`}
+                >
+                  <span>{faq.q}</span>
+                  <span class="kc-faq-sign" aria-hidden="true">{i === 0 ? '–' : '+'}</span>
+                </button>
+              </h3>
+              <p class="kc-faq-a" id={`kc-faq-a-${i}`} role="region" aria-labelledby={`kc-faq-q-${i}`} hidden={i !== 0}>
+                {faq.a}
+              </p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <section class="kc-contact" aria-labelledby="kc-contact-title">
+      <div class="kc-contact-inner">
+        <div>
+          <h2 id="kc-contact-title">
+            Napisz jednym zdaniem, co chcesz usprawnić. Ja, albo mój brat odpowiemy osobiście.
+          </h2>
+          <a href={mailto} class="kc-btn">info@kunkeconsulting.pl</a>
+          <div class="kc-notes" data-kc-notes>
+            <p class="kc-note">
+              Przypis: pierwsza rozmowa jest bezpłatna i trwa 30 minut. Jeśli nie jestem właściwą
+              osobą, powiem to w jej trakcie.
+            </p>
+          </div>
+        </div>
+        <div class="kc-contact-details">
+          <p class="kc-eyebrow">Kontakt</p>
+          <p>^Kunke Consulting · Poznań</p>
+          <a href="tel:+48722156925">+48 722 156 925</a>
+          <a href="https://www.linkedin.com/in/blazejkunke/" rel="noopener">LinkedIn</a>
+          <a href="/blog/">Blog</a>
+          <a href="https://www.youtube.com/@BlazeAdventuresWorld" rel="noopener">YouTube</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="kc-footer">
+    <div class="kc-footer-inner">
+      <p>© 2026 ^Kunke Consulting</p>
+      <div class="kc-footer-links">
+        <a href="/privacy-policy/">Polityka prywatności</a>
+        <a href="/ai-info/">Dla robotów</a>
+        <a href="/en/">EN</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // "detale" toggles the marginal notes; the design ships them visible.
+    const toggle = document.getElementById('kc-notes-toggle');
+    const noteGroups = Array.from(document.querySelectorAll('[data-kc-notes]'));
+
+    toggle?.addEventListener('click', () => {
+      const showing = toggle.getAttribute('aria-pressed') === 'true';
+      const next = !showing;
+      toggle.setAttribute('aria-pressed', String(next));
+      noteGroups.forEach((group) => {
+        if (next) {
+          group.removeAttribute('hidden');
+        } else {
+          group.setAttribute('hidden', '');
+        }
+      });
+    });
+
+    // FAQ: single item open at a time, first one open on load.
+    const questions = Array.from(document.querySelectorAll('.kc-faq-q'));
+
+    questions.forEach((question) => {
+      question.addEventListener('click', () => {
+        const wasOpen = question.getAttribute('aria-expanded') === 'true';
+
+        questions.forEach((other) => {
+          const answerId = other.getAttribute('aria-controls');
+          const answer = answerId ? document.getElementById(answerId) : null;
+          const sign = other.querySelector('.kc-faq-sign');
+          const open = other === question && !wasOpen;
+
+          other.setAttribute('aria-expanded', String(open));
+          if (sign) sign.textContent = open ? '–' : '+';
+          if (answer) {
+            if (open) {
+              answer.removeAttribute('hidden');
+            } else {
+              answer.setAttribute('hidden', '');
+            }
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Implements the Claude Design homepage concept ([Homepage.dc.html](https://claude.ai/design/p/c2cd1653-b5be-4093-80f3-f866f1d9ecaf?file=Homepage.dc.html)) as a new route at `/redesigned/`, so the new direction can be reviewed on the real site next to the current homepage.

## What's in it

Cream/forest-green palette, sticky header with the `detale` notes toggle, stats band, three-step process, three offer cards, PragmatIQ case-study panel, About, quotes, team, FAQ accordion, contact and footer — desktop and mobile layouts both from the design.

## Notes for review

- **Does not use `BaseLayout`.** `global.css` forces its own type scale, centred `h2`s and section widths, which override the redesign. Consequence: this page has no GTM, cookie banner or language switcher yet — those need wiring up before it could replace `index.astro`.
- **`noindex, nofollow` + excluded from the sitemap**, so it can't compete with the homepage in search while it's a preview.
- **The design's About paragraph ended mid-sentence** (`...zawsze starając się dostarczyć (...)`). Completed as *"Obiecuję dokładnie tyle, ile potrafimy dowieźć — i staram się dostarczyć więcej."* — worth a second look.
- Jan Kunke's photo uses the live `/images/team/jan-kunke-team.jpg` rather than the design project's local upload.
- Stats band is 2x2 on tablets; four across went ragged at 768px.

## Verification

`npm run build` passes (45 pages). Checked in a browser at 1280 / 768 / 375px: desktop grids match the design's numbers, no horizontal overflow at any width, no console errors, photos served as WebP. The `detale` toggle and the accordion match the design's logic (first item open, one at a time, clicking an open one closes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)