### PR TITLE
Make the small type on the English homepage readable

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -252,7 +252,7 @@ const faqs = [
       --kc-ink: #12201b;
       --kc-green: #0a4731;
       --kc-body: #3a4a43;
-      --kc-muted: #6b7b73;
+      --kc-muted: #52625a;
       --kc-card: #ffffff;
       --kc-rule-08: rgba(10, 71, 49, 0.08);
       --kc-rule-10: rgba(10, 71, 49, 0.1);
@@ -325,8 +325,8 @@ const faqs = [
 
     .kc-eyebrow {
       font-family: var(--kc-mono);
-      font-size: 11px;
-      letter-spacing: 0.14em;
+      font-size: 13px;
+      letter-spacing: 0.1em;
       text-transform: uppercase;
       color: var(--kc-muted);
       margin: 0;
@@ -334,7 +334,7 @@ const faqs = [
 
     .kc-note {
       font-family: var(--kc-mono);
-      font-size: 12px;
+      font-size: 14px;
       line-height: 1.7;
       color: var(--kc-muted);
       border-left: 1px solid var(--kc-rule-18);
@@ -403,7 +403,7 @@ const faqs = [
       display: flex;
       gap: 26px;
       margin-left: auto;
-      font-size: 14px;
+      font-size: 16px;
     }
 
     .kc-nav-links a {
@@ -411,7 +411,7 @@ const faqs = [
     }
 
     .kc-nav .kc-btn {
-      font-size: 14px;
+      font-size: 15px;
       padding: 8px 16px;
     }
 
@@ -481,7 +481,7 @@ const faqs = [
     }
 
     .kc-hero-notes .kc-note {
-      font-size: 12px;
+      font-size: 14px;
       line-height: 1.6;
     }
 
@@ -517,7 +517,7 @@ const faqs = [
 
     .kc-polaroid figcaption {
       font-family: var(--kc-mono);
-      font-size: 11px;
+      font-size: 13px;
       letter-spacing: 0.08em;
       text-align: center;
       color: var(--kc-muted);
@@ -550,7 +550,7 @@ const faqs = [
     }
 
     .kc-fact-small {
-      font-size: 13px;
+      font-size: 15px;
       line-height: 1.45;
       color: var(--kc-muted);
       margin: 6px 0 0;
@@ -600,7 +600,7 @@ const faqs = [
 
     .kc-step-label {
       font-family: var(--kc-mono);
-      font-size: 11px;
+      font-size: 13px;
       color: var(--kc-muted);
       margin: 0 0 12px;
     }
@@ -645,7 +645,7 @@ const faqs = [
 
     .kc-card-tag {
       font-family: var(--kc-mono);
-      font-size: 11px;
+      font-size: 13px;
       letter-spacing: 0.1em;
       text-transform: uppercase;
       color: var(--kc-muted);
@@ -676,7 +676,7 @@ const faqs = [
     }
 
     .kc-card-items li {
-      font-size: 14px;
+      font-size: 15px;
       line-height: 1.45;
       color: var(--kc-body);
       padding-left: 16px;
@@ -700,7 +700,7 @@ const faqs = [
     }
 
     .kc-card-foot a {
-      font-size: 14px;
+      font-size: 15px;
       white-space: nowrap;
     }
 
@@ -869,7 +869,7 @@ const faqs = [
     }
 
     .kc-quote figcaption {
-      font-size: 13px;
+      font-size: 15px;
       color: var(--kc-muted);
     }
 
@@ -912,7 +912,7 @@ const faqs = [
     }
 
     .kc-team-role {
-      font-size: 14px;
+      font-size: 15px;
       color: var(--kc-muted);
       margin: 0;
     }
@@ -958,7 +958,7 @@ const faqs = [
 
     .kc-faq-sign {
       font-family: var(--kc-mono);
-      font-size: 14px;
+      font-size: 16px;
       color: var(--kc-muted);
     }
 
@@ -1011,7 +1011,7 @@ const faqs = [
       display: flex;
       flex-direction: column;
       gap: 14px;
-      font-size: 15px;
+      font-size: 16px;
       color: var(--kc-body);
     }
 
@@ -1038,7 +1038,7 @@ const faqs = [
       align-items: center;
       gap: 24px;
       flex-wrap: wrap;
-      font-size: 13px;
+      font-size: 15px;
       color: var(--kc-muted);
     }
 
@@ -1191,7 +1191,7 @@ const faqs = [
       }
 
       .kc-eyebrow {
-        font-size: 10px;
+        font-size: 12px;
       }
 
       .kc-hero h1 {
@@ -1244,7 +1244,7 @@ const faqs = [
       }
 
       .kc-fact-small {
-        font-size: 12px;
+        font-size: 14px;
       }
 
       .kc-section {
@@ -1327,7 +1327,7 @@ const faqs = [
       }
 
       .kc-team-role {
-        font-size: 13px;
+        font-size: 15px;
       }
 
       .kc-faq-q {


### PR DESCRIPTION
The eyebrows, nav links, captions and labels were set in 10–14px, several of them in wide-tracked uppercase mono, and the muted grey sat at **4.22:1** against the cream background — under the 4.5:1 AA threshold for normal text.

**Changes**
- Eyebrows 11 → 13px, tracking eased 0.14em → 0.1em
- Nav links 14 → 16px; nav button 14 → 15px
- Hero notes and polaroid caption 11–12 → 13–14px
- Fact captions, step labels, card tags, team roles, quote attributions, footer 11–14 → 13–15px
- Mobile overrides raised to match (eyebrow 10 → 12px, fact caption 12 → 14px, team role 13 → 15px)
- `--kc-muted` darkened `#6b7b73` → `#52625a`

Headings, body copy, spacing and layout are untouched.

**Verified**
- Contrast now 5.93:1 – 9.37:1 on every muted element (composited against the actual tinted backgrounds, not the raw token).
- The dark case-study panel overrides the eyebrow color separately, so it is unaffected — still 10.18:1.
- Nav fits on one line; no horizontal overflow at 375px or 1280px; offer cards stay equal height.
- `npm run build` 45 pages, `npx astro check` 0 errors.

Note: `/redesigned` still carries the original sizes, so the Polish preview and `/en/` have drifted apart on type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)