### PR TITLE
Sync the /redesigned type scale with /en/, and fix the nav breakpoint

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1159,6 +1159,20 @@ const faqs = [
 
     /* ---------- phone ---------- */
 
+    /* The 16px anchor labels stop fitting beside the brand and the CTA at
+       roughly 700px, which wraps the brand onto two lines, so the nav drops
+       to brand + CTA well before the phone breakpoint. */
+    @media (max-width: 768px) {
+      .kc-nav-links {
+        display: none;
+      }
+
+      /* With the anchor nav hidden, the CTA carries the right edge. */
+      .kc-nav .kc-btn {
+        margin-left: auto;
+      }
+    }
+
     @media (max-width: 600px) {
       :root {
         --kc-gut: 20px;
@@ -1166,11 +1180,6 @@ const faqs = [
 
       .kc-nav {
         gap: 12px;
-      }
-
-      /* Anchor nav is dropped on phones, as in the mobile design. */
-      .kc-nav-links {
-        display: none;
       }
 
       .kc-brand {

--- a/src/pages/redesigned.astro
+++ b/src/pages/redesigned.astro
@@ -147,7 +147,7 @@ const faqs = [
       --kc-ink: #12201b;
       --kc-green: #0a4731;
       --kc-body: #3a4a43;
-      --kc-muted: #6b7b73;
+      --kc-muted: #52625a;
       --kc-card: #ffffff;
       --kc-rule-08: rgba(10, 71, 49, 0.08);
       --kc-rule-10: rgba(10, 71, 49, 0.1);
@@ -220,8 +220,8 @@ const faqs = [
 
     .kc-eyebrow {
       font-family: var(--kc-mono);
-      font-size: 11px;
-      letter-spacing: 0.14em;
+      font-size: 13px;
+      letter-spacing: 0.1em;
       text-transform: uppercase;
       color: var(--kc-muted);
       margin: 0;
@@ -229,7 +229,7 @@ const faqs = [
 
     .kc-note {
       font-family: var(--kc-mono);
-      font-size: 12px;
+      font-size: 14px;
       line-height: 1.7;
       color: var(--kc-muted);
       border-left: 1px solid var(--kc-rule-18);
@@ -298,7 +298,7 @@ const faqs = [
       display: flex;
       gap: 26px;
       margin-left: auto;
-      font-size: 14px;
+      font-size: 16px;
     }
 
     .kc-nav-links a {
@@ -306,7 +306,7 @@ const faqs = [
     }
 
     .kc-nav .kc-btn {
-      font-size: 14px;
+      font-size: 15px;
       padding: 8px 16px;
     }
 
@@ -376,7 +376,7 @@ const faqs = [
     }
 
     .kc-hero-notes .kc-note {
-      font-size: 12px;
+      font-size: 14px;
       line-height: 1.6;
     }
 
@@ -412,7 +412,7 @@ const faqs = [
 
     .kc-polaroid figcaption {
       font-family: var(--kc-mono);
-      font-size: 11px;
+      font-size: 13px;
       letter-spacing: 0.08em;
       text-align: center;
       color: var(--kc-muted);
@@ -445,7 +445,7 @@ const faqs = [
     }
 
     .kc-fact-small {
-      font-size: 13px;
+      font-size: 15px;
       line-height: 1.45;
       color: var(--kc-muted);
       margin: 6px 0 0;
@@ -495,7 +495,7 @@ const faqs = [
 
     .kc-step-label {
       font-family: var(--kc-mono);
-      font-size: 11px;
+      font-size: 13px;
       color: var(--kc-muted);
       margin: 0 0 12px;
     }
@@ -540,7 +540,7 @@ const faqs = [
 
     .kc-card-tag {
       font-family: var(--kc-mono);
-      font-size: 11px;
+      font-size: 13px;
       letter-spacing: 0.1em;
       text-transform: uppercase;
       color: var(--kc-muted);
@@ -571,7 +571,7 @@ const faqs = [
     }
 
     .kc-card-items li {
-      font-size: 14px;
+      font-size: 15px;
       line-height: 1.45;
       color: var(--kc-body);
       padding-left: 16px;
@@ -595,7 +595,7 @@ const faqs = [
     }
 
     .kc-card-foot a {
-      font-size: 14px;
+      font-size: 15px;
       white-space: nowrap;
     }
 
@@ -764,7 +764,7 @@ const faqs = [
     }
 
     .kc-quote figcaption {
-      font-size: 13px;
+      font-size: 15px;
       color: var(--kc-muted);
     }
 
@@ -807,7 +807,7 @@ const faqs = [
     }
 
     .kc-team-role {
-      font-size: 14px;
+      font-size: 15px;
       color: var(--kc-muted);
       margin: 0;
     }
@@ -853,7 +853,7 @@ const faqs = [
 
     .kc-faq-sign {
       font-family: var(--kc-mono);
-      font-size: 14px;
+      font-size: 16px;
       color: var(--kc-muted);
     }
 
@@ -906,7 +906,7 @@ const faqs = [
       display: flex;
       flex-direction: column;
       gap: 14px;
-      font-size: 15px;
+      font-size: 16px;
       color: var(--kc-body);
     }
 
@@ -933,7 +933,7 @@ const faqs = [
       align-items: center;
       gap: 24px;
       flex-wrap: wrap;
-      font-size: 13px;
+      font-size: 15px;
       color: var(--kc-muted);
     }
 
@@ -1086,7 +1086,7 @@ const faqs = [
       }
 
       .kc-eyebrow {
-        font-size: 10px;
+        font-size: 12px;
       }
 
       .kc-hero h1 {
@@ -1139,7 +1139,7 @@ const faqs = [
       }
 
       .kc-fact-small {
-        font-size: 12px;
+        font-size: 14px;
       }
 
       .kc-section {
@@ -1222,7 +1222,7 @@ const faqs = [
       }
 
       .kc-team-role {
-        font-size: 13px;
+        font-size: 15px;
       }
 
       .kc-faq-q {

--- a/src/pages/redesigned.astro
+++ b/src/pages/redesigned.astro
@@ -1054,6 +1054,20 @@ const faqs = [
 
     /* ---------- phone ---------- */
 
+    /* The 16px anchor labels stop fitting beside the brand and the CTA at
+       roughly 700px, which wraps the brand onto two lines, so the nav drops
+       to brand + CTA well before the phone breakpoint. */
+    @media (max-width: 768px) {
+      .kc-nav-links {
+        display: none;
+      }
+
+      /* With the anchor nav hidden, the CTA carries the right edge. */
+      .kc-nav .kc-btn {
+        margin-left: auto;
+      }
+    }
+
     @media (max-width: 600px) {
       :root {
         --kc-gut: 20px;
@@ -1061,11 +1075,6 @@ const faqs = [
 
       .kc-nav {
         gap: 12px;
-      }
-
-      /* Anchor nav is dropped on phones, as in the mobile design. */
-      .kc-nav-links {
-        display: none;
       }
 
       .kc-brand {


### PR DESCRIPTION
Two commits.

**1. Sync the type scale.** #172 raised the small type and darkened `--kc-muted` on `/en/` but left `redesigned.astro` untouched, so the two pages drifted apart. `/en/` mirrors the Polish homepage's design, and `/redesigned` is the plan for that homepage, so the same readability problem would return the day it goes live. The 21 changed declarations are copied across and the two `<style is:global>` blocks are byte-identical again — future visual changes apply once, to both.

**2. Fix the nav breakpoint** (found by the automated review on this PR, and confirmed by measurement).

The larger 16px labels need **704px** of nav width in English and **649px** in Polish, but `.kc-nav-links` stayed visible down to 601px. In that gap the flex row could not fit brand, links and CTA on one line, so `^Kunke Consulting` wrapped onto two lines and the nav grew from 66px to 73px. Measured at 640px: brand 21px tall at the old 14px, 41px at 16px.

`/en/` was the worse case — five labels, longer words — and it is already live, so this fixes a defect in production, not just in the preview.

The anchor links now hide below **768px**, with the CTA's right-edge alignment moved into the same query so it still carries the right edge. Between 601 and 768px the nav is brand + CTA, the treatment phones already get.

**Verified on both pages**
- 640px and 660px: brand on one line, links hidden, CTA right-aligned at the 32px gutter, nav back to 66px, no horizontal overflow.
- 780px: links visible and fitting with ~60px of slack.
- 375px, 900px, 1265px: unchanged and clean.
- `npm run build` 45 pages, `npx astro check` 0 errors.

`/redesigned` remains `noindex` and excluded from the sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)